### PR TITLE
Fix for classic toUpperCase gotcha when locale is Turkish

### DIFF
--- a/jansi/src/main/java/org/fusesource/jansi/AnsiRenderer.java
+++ b/jansi/src/main/java/org/fusesource/jansi/AnsiRenderer.java
@@ -16,6 +16,8 @@
 
 package org.fusesource.jansi;
 
+import java.util.Locale;
+
 import org.fusesource.jansi.Ansi.Attribute;
 import org.fusesource.jansi.Ansi.Color;
 
@@ -102,7 +104,7 @@ public class AnsiRenderer
     static private String render(final String text, final String... codes) {
         Ansi ansi = Ansi.ansi();
         for (String name : codes) {
-            Code code = Code.valueOf(name.toUpperCase());
+            Code code = Code.valueOf(name.toUpperCase(Locale.ENGLISH));
 
             if (code.isColor()) {
                 if (code.isBackground()) {


### PR DESCRIPTION
Locale.English or things will go wrong when running on the Turkish
locale.

See http://mattryall.net/blog/2009/02/the-infamous-turkish-locale-bug

and other Google results:
https://www.google.com/search?q=java+toUpperCase+turkish&ie=utf-8&oe=utf-8&aq=t&rls=org.mozilla:en-US:official&client=firefox-a
