### PR TITLE
missing functions for default text and background colors on Windows

### DIFF
--- a/jansi/src/main/java/org/fusesource/jansi/WindowsAnsiOutputStream.java
+++ b/jansi/src/main/java/org/fusesource/jansi/WindowsAnsiOutputStream.java
@@ -239,6 +239,18 @@ public final class WindowsAnsiOutputStream extends AnsiOutputStream {
 	}
 
 	@Override
+	protected void processDefaultTextColor() throws IOException {
+		info.attributes = (short)((info.attributes & ~0x000F ) | (originalColors & 0xF));
+		applyAttribute();
+	}
+	
+	@Override
+	protected void processDefaultBackgroundColor() throws IOException {
+		info.attributes = (short)((info.attributes & ~0x00F0 ) | (originalColors & 0xF0));
+		applyAttribute();
+	}
+
+	@Override
 	protected void processAttributeRest() throws IOException {
 		info.attributes = (short)((info.attributes & ~0x00FF ) | originalColors);
         this.negative = false;


### PR DESCRIPTION
Hey guys,

last day, my anger beat my patience... I'm using the Grails Web Application Framework for some projects since over a year now and it's console output leaves an unfinished/unprofessional impression. On Linux it looks much better.

My plan was to fix it with a contribution to the Grails code-base again. Many hours later, the workaround for Windows special treatment was working. Like many people before me, who uses jansi, i came to the same conclusion that Windows simply doesn't support any way to get or set the default text or background colors on a standard console window.

Grails uses jansi for it's console output. So i pulled jansi's source, to understand how to use it the right way. Found out it uses a dedicated Windows Console API. Looking how that API works: it supported to read and set default colors. But what is wrong with that, why does it not work in jansi?

Then hit me the lightning. That code was simply not implemented. Forgotten maybe.

This pull request is a pretty simple one, but it helps a lot to emulate the same behaviour on different platforms. Setting the default text and background color is a core functionality of your API (and ANSI).

I sacrificed over a day for this small outcome. You give me much reward if you integrate this pull-request and publish a new release quickly. Then God don't need to kill a innocent kitten each day ;)

Thank you for your time!
