### PR TITLE
Adding Cygwin detection

### DIFF
--- a/jansi/src/main/java/org/fusesource/jansi/AnsiConsole.java
+++ b/jansi/src/main/java/org/fusesource/jansi/AnsiConsole.java
@@ -56,7 +56,7 @@ public class AnsiConsole {
         }
 
 		String os = System.getProperty("os.name");
-		if( os.startsWith("Windows") ) {
+		if( os.startsWith("Windows") && !tmpDir.contains("cygwin") ) { //add check for Cygwin
 			
 			// On windows we know the console does not interpret ANSI codes..
 			try {
@@ -78,6 +78,8 @@ public class AnsiConsole {
 			// If we can detect that stdout is not a tty.. then setup
 			// to strip the ANSI sequences..
 			int rc = isatty(STDOUT_FILENO);
+			if(tmpDir.contains("cygwin"))
+                		rc=1;//Detect if it's a Cygwin console. If it is, override this check because mintty doesn't report itself as a TTY correctly
 			if( !forceColored && rc==0 ) {
 				return new AnsiOutputStream(stream);
 			}

--- a/jansi/src/main/java/org/fusesource/jansi/AnsiConsole.java
+++ b/jansi/src/main/java/org/fusesource/jansi/AnsiConsole.java
@@ -56,6 +56,7 @@ public class AnsiConsole {
         }
 
 		String os = System.getProperty("os.name");
+		String tmpDir= System.getProperty("java.io.tmpdir");
 		if( os.startsWith("Windows") && !tmpDir.contains("cygwin") ) { //add check for Cygwin
 			
 			// On windows we know the console does not interpret ANSI codes..


### PR DESCRIPTION
Added ability to detect Cygwin consoles by checking the tmp directory - when run from a Cygwin shell, it's usually something like C:\cygwin\tmp. It checks to see if the tmp directory contains "cygwin", and if it does, assumes it's running from a Cygwin shell.