### PR TITLE
Clean imports

### DIFF
--- a/jansi/src/main/java/org/fusesource/jansi/Ansi.java
+++ b/jansi/src/main/java/org/fusesource/jansi/Ansi.java
@@ -16,8 +16,8 @@
  */
 package org.fusesource.jansi;
 
-import java.util.ArrayList;
-import java.util.concurrent.Callable;
+import java.util.*;
+import java.util.concurrent.*;
 
 /**
  * Provides a fluent API for generating ANSI escape sequences.

--- a/jansi/src/main/java/org/fusesource/jansi/AnsiConsole.java
+++ b/jansi/src/main/java/org/fusesource/jansi/AnsiConsole.java
@@ -17,14 +17,9 @@
 
 package org.fusesource.jansi;
 
-import static org.fusesource.jansi.internal.CLibrary.STDERR_FILENO;
-import static org.fusesource.jansi.internal.CLibrary.STDOUT_FILENO;
-import static org.fusesource.jansi.internal.CLibrary.isatty;
+import static org.fusesource.jansi.internal.CLibrary.*;
 
-import java.io.FilterOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.io.PrintStream;
+import java.io.*;
 
 /**
  * Provides consistent access to an ANSI aware console PrintStream.

--- a/jansi/src/main/java/org/fusesource/jansi/AnsiOutputStream.java
+++ b/jansi/src/main/java/org/fusesource/jansi/AnsiOutputStream.java
@@ -17,11 +17,8 @@
 
 package org.fusesource.jansi;
 
-import java.io.FilterOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.io.UnsupportedEncodingException;
-import java.util.ArrayList;
+import java.io.*;
+import java.util.*;
 
 /**
  * A ANSI output stream extracts ANSI escape codes written to 

--- a/jansi/src/main/java/org/fusesource/jansi/AnsiRenderWriter.java
+++ b/jansi/src/main/java/org/fusesource/jansi/AnsiRenderWriter.java
@@ -16,10 +16,8 @@
 
 package org.fusesource.jansi;
 
-import java.io.OutputStream;
-import java.io.PrintWriter;
-import java.io.Writer;
-import java.util.Locale;
+import java.io.*;
+import java.util.*;
 
 import static org.fusesource.jansi.AnsiRenderer.*;
 

--- a/jansi/src/main/java/org/fusesource/jansi/AnsiRenderer.java
+++ b/jansi/src/main/java/org/fusesource/jansi/AnsiRenderer.java
@@ -16,10 +16,9 @@
 
 package org.fusesource.jansi;
 
-import java.util.Locale;
+import java.util.*;
 
-import org.fusesource.jansi.Ansi.Attribute;
-import org.fusesource.jansi.Ansi.Color;
+import org.fusesource.jansi.Ansi.*;
 
 /**
  * Renders ANSI color escape-codes in strings by parsing out some special syntax to pick up the correct fluff to use.

--- a/jansi/src/main/java/org/fusesource/jansi/AnsiRenderer.java
+++ b/jansi/src/main/java/org/fusesource/jansi/AnsiRenderer.java
@@ -18,6 +18,7 @@ package org.fusesource.jansi;
 
 import java.util.*;
 
+//Might need to change this back
 import org.fusesource.jansi.Ansi.*;
 
 /**

--- a/jansi/src/main/java/org/fusesource/jansi/AnsiString.java
+++ b/jansi/src/main/java/org/fusesource/jansi/AnsiString.java
@@ -16,10 +16,9 @@
 
 package org.fusesource.jansi;
 
-import org.fusesource.jansi.AnsiOutputStream;
+import org.fusesource.jansi.*;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
+import java.io.*;
 
 /**
  * An ANSI string which reports the size of rendered text correctly (ignoring any ANSI escapes).

--- a/jansi/src/main/java/org/fusesource/jansi/HtmlAnsiOutputStream.java
+++ b/jansi/src/main/java/org/fusesource/jansi/HtmlAnsiOutputStream.java
@@ -17,12 +17,10 @@
 
 package org.fusesource.jansi;
 
-import java.io.IOException;
-import java.io.OutputStream;
-import java.util.ArrayList;
-import java.util.List;
+import java.io.*;
+import java.util.*;
 
-import org.fusesource.jansi.AnsiOutputStream;
+import org.fusesource.jansi.*;
 
 /**
  * @author <a href="http://code.dblock.org">Daniel Doubrovkine</a>

--- a/jansi/src/main/java/org/fusesource/jansi/WindowsAnsiOutputStream.java
+++ b/jansi/src/main/java/org/fusesource/jansi/WindowsAnsiOutputStream.java
@@ -16,29 +16,12 @@
  */
 package org.fusesource.jansi;
 
-import static org.fusesource.jansi.internal.Kernel32.BACKGROUND_BLUE;
-import static org.fusesource.jansi.internal.Kernel32.BACKGROUND_GREEN;
-import static org.fusesource.jansi.internal.Kernel32.BACKGROUND_INTENSITY;
-import static org.fusesource.jansi.internal.Kernel32.BACKGROUND_RED;
-import static org.fusesource.jansi.internal.Kernel32.FOREGROUND_BLUE;
-import static org.fusesource.jansi.internal.Kernel32.FOREGROUND_GREEN;
-import static org.fusesource.jansi.internal.Kernel32.FOREGROUND_INTENSITY;
-import static org.fusesource.jansi.internal.Kernel32.FOREGROUND_RED;
-import static org.fusesource.jansi.internal.Kernel32.FillConsoleOutputAttribute;
-import static org.fusesource.jansi.internal.Kernel32.FillConsoleOutputCharacterW;
-import static org.fusesource.jansi.internal.Kernel32.GetConsoleScreenBufferInfo;
-import static org.fusesource.jansi.internal.Kernel32.GetStdHandle;
-import static org.fusesource.jansi.internal.Kernel32.STD_OUTPUT_HANDLE;
-import static org.fusesource.jansi.internal.Kernel32.SetConsoleCursorPosition;
-import static org.fusesource.jansi.internal.Kernel32.SetConsoleTextAttribute;
-import static org.fusesource.jansi.internal.Kernel32.SetConsoleTitle;
+import static org.fusesource.jansi.internal.Kernel32.*;
 
-import java.io.IOException;
-import java.io.OutputStream;
+import java.io.*;
 
 import org.fusesource.jansi.internal.WindowsSupport;
-import org.fusesource.jansi.internal.Kernel32.CONSOLE_SCREEN_BUFFER_INFO;
-import org.fusesource.jansi.internal.Kernel32.COORD;
+import org.fusesource.jansi.internal.Kernel32.*;
 
 /**
  * A Windows ANSI escape processor, uses JNA to access native platform


### PR DESCRIPTION
Cleaned Most Imports. Some Imports are not needed with a '*' but is good, because if in the future classes under these packages are added, you do not need to import more.