### PR TITLE
Multiple code improvements - squid:SwitchLastCaseIsDefaultCheck, squid:S1197, squid:S1118

### DIFF
--- a/jansi/src/main/java/org/fusesource/jansi/AnsiConsole.java
+++ b/jansi/src/main/java/org/fusesource/jansi/AnsiConsole.java
@@ -42,6 +42,8 @@ public class AnsiConsole {
 
     private static int installed;
 
+	private AnsiConsole() {}
+
 	public static OutputStream wrapOutputStream(final OutputStream stream) {
 		return wrapOutputStream(stream, STDOUT_FILENO);
 	}

--- a/jansi/src/main/java/org/fusesource/jansi/AnsiOutputStream.java
+++ b/jansi/src/main/java/org/fusesource/jansi/AnsiOutputStream.java
@@ -47,7 +47,7 @@ public class AnsiOutputStream extends FilterOutputStream {
 	}
 
 	private  final static int MAX_ESCAPE_SEQUENCE_LENGTH=100;
-	private byte buffer[] = new byte[MAX_ESCAPE_SEQUENCE_LENGTH];
+	private byte[] buffer = new byte[MAX_ESCAPE_SEQUENCE_LENGTH];
 	private int pos=0;
 	private int startOfValue;
 	private final ArrayList<Object> options = new ArrayList<Object>();
@@ -111,6 +111,8 @@ public class AnsiOutputStream extends FilterOutputStream {
 			} else {
 				reset( processEscapeCommand(options, data) );
 			}
+			break;
+		default:
 			break;
 
 		case LOOKING_FOR_INT_ARG_END:

--- a/jansi/src/main/java/org/fusesource/jansi/AnsiRenderer.java
+++ b/jansi/src/main/java/org/fusesource/jansi/AnsiRenderer.java
@@ -58,6 +58,8 @@ public class AnsiRenderer
 
     public static final String CODE_LIST_SEPARATOR = ",";
 
+    private AnsiRenderer() {}
+
     static public String render(final String input) throws IllegalArgumentException {
         StringBuffer buff = new StringBuffer();
 

--- a/jansi/src/main/java/org/fusesource/jansi/HtmlAnsiOutputStream.java
+++ b/jansi/src/main/java/org/fusesource/jansi/HtmlAnsiOutputStream.java
@@ -37,7 +37,7 @@ public class HtmlAnsiOutputStream extends AnsiOutputStream {
 		super.close();
 	}
 
-	private static final String ANSI_COLOR_MAP[] = { "black", "red",
+	private static final String[] ANSI_COLOR_MAP = { "black", "red",
 			"green", "yellow", "blue", "magenta", "cyan", "white", };
 
 	private static final byte[] BYTES_QUOT = "&quot;".getBytes();
@@ -113,6 +113,8 @@ public class HtmlAnsiOutputStream extends AnsiOutputStream {
 		case ATTRIBUTE_NEGATIVE_ON:
 			break;
 		case ATTRIBUTE_NEGATIVE_Off:
+			break;
+		default:
 			break;
 		}
 	}

--- a/jansi/src/main/java/org/fusesource/jansi/WindowsAnsiOutputStream.java
+++ b/jansi/src/main/java/org/fusesource/jansi/WindowsAnsiOutputStream.java
@@ -64,7 +64,7 @@ public final class WindowsAnsiOutputStream extends AnsiOutputStream {
     private static final short BACKGROUND_CYAN    = (short) (BACKGROUND_BLUE|BACKGROUND_GREEN);
     private static final short BACKGROUND_WHITE   = (short) (BACKGROUND_RED|BACKGROUND_GREEN|BACKGROUND_BLUE);
     
-    private static final short ANSI_FOREGROUND_COLOR_MAP[] = {
+    private static final short[] ANSI_FOREGROUND_COLOR_MAP = {
     	FOREGROUND_BLACK,
     	FOREGROUND_RED,
     	FOREGROUND_GREEN,
@@ -75,7 +75,7 @@ public final class WindowsAnsiOutputStream extends AnsiOutputStream {
     	FOREGROUND_WHITE,
     };
         
-    private static final short ANSI_BACKGROUND_COLOR_MAP[] = {
+    private static final short[] ANSI_BACKGROUND_COLOR_MAP = {
     	BACKGROUND_BLACK,
     	BACKGROUND_RED,
     	BACKGROUND_GREEN,
@@ -163,6 +163,9 @@ public final class WindowsAnsiOutputStream extends AnsiOutputStream {
 				(info.size.x - info.cursorPosition.x);
 			FillConsoleOutputAttribute(console, originalColors, lengthToEnd, info.cursorPosition.copy(), written);
 			FillConsoleOutputCharacterW(console, ' ', lengthToEnd, info.cursorPosition.copy(), written);
+			break;
+		default:
+			break;
 		}		
 	}
 	
@@ -187,6 +190,9 @@ public final class WindowsAnsiOutputStream extends AnsiOutputStream {
 			int lengthToLastCol = info.size.x - info.cursorPosition.x;
 			FillConsoleOutputAttribute(console, originalColors, lengthToLastCol, info.cursorPosition.copy(), written);
 			FillConsoleOutputCharacterW(console, ' ', lengthToLastCol, info.cursorPosition.copy(), written);
+			break;
+		default:
+			break;
 		}
 	}
 	
@@ -294,6 +300,8 @@ public final class WindowsAnsiOutputStream extends AnsiOutputStream {
 			case ATTRIBUTE_NEGATIVE_Off:
 				negative = false;
 				applyAttribute();
+				break;
+			default:
 				break;
 		}
 	}

--- a/jansi/src/test/java/org/fusesource/jansi/AnsiConsoleExample.java
+++ b/jansi/src/test/java/org/fusesource/jansi/AnsiConsoleExample.java
@@ -25,6 +25,8 @@ import java.io.IOException;
  */
 public class AnsiConsoleExample {
 
+    private AnsiConsoleExample() {}
+
 	public static void main(String[] args) throws IOException {
         String file = "src/test/resources/jansi.ans";
         if( args.length>0  )

--- a/jansi/src/test/java/org/fusesource/jansi/AnsiConsoleExample2.java
+++ b/jansi/src/test/java/org/fusesource/jansi/AnsiConsoleExample2.java
@@ -26,6 +26,8 @@ import static org.fusesource.jansi.Ansi.*;
  */
 public class AnsiConsoleExample2 {
 
+    private AnsiConsoleExample2() {}
+
 	public static void main(String[] args) throws IOException {
         String file = "src/test/resources/jansi.ans";
         if( args.length>0  )


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:SwitchLastCaseIsDefaultCheck - "switch" statements should end with a "default" clause.
squid:S1197 - Array designators "[]" should be on the type, not the variable.
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:SwitchLastCaseIsDefaultCheck
https://dev.eclipse.org/sonar/rules/show/squid:S1197
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
George Kankava