### PR TITLE
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

### DIFF
--- a/jansi/src/main/java/org/fusesource/jansi/Ansi.java
+++ b/jansi/src/main/java/org/fusesource/jansi/Ansi.java
@@ -27,8 +27,43 @@ import java.util.concurrent.Callable;
  */
 public class Ansi {
 
-    private static final char FIRST_ESC_CHAR = 27;
+	public static final String DISABLE = Ansi.class.getName() + ".disable";
+
+	private static final char FIRST_ESC_CHAR = 27;
 	private static final char SECOND_ESC_CHAR = '[';
+	private static final InheritableThreadLocal<Boolean> holder = new InheritableThreadLocal<Boolean>()
+	{
+		@Override
+		protected Boolean initialValue() {
+			return isDetected();
+		}
+	};
+	private static Callable<Boolean> detector = new Callable<Boolean>() {
+		public Boolean call() throws Exception {
+			return !Boolean.getBoolean(DISABLE);
+		}
+	};
+
+	private final StringBuilder builder;
+	private final ArrayList<Integer> attributeOptions = new ArrayList<Integer>(5);
+
+	public Ansi() {
+		this(new StringBuilder());
+	}
+
+	public Ansi(Ansi parent) {
+		this(new StringBuilder(parent.builder));
+		attributeOptions.addAll(parent.attributeOptions);
+	}
+
+	public Ansi(int size) {
+		this(new StringBuilder(size));
+	}
+
+	public Ansi(StringBuilder builder) {
+		this.builder = builder;
+	}
+
 
 	public static enum Color {
 		BLACK(0, "BLACK"), 
@@ -137,14 +172,6 @@ public class Ansi {
 		}
 	};
 
-    public static final String DISABLE = Ansi.class.getName() + ".disable";
-
-    private static Callable<Boolean> detector = new Callable<Boolean>() {
-        public Boolean call() throws Exception {
-            return !Boolean.getBoolean(DISABLE);
-        }
-    };
-
     public static void setDetector(final Callable<Boolean> detector) {
         if (detector == null) throw new IllegalArgumentException();
         Ansi.detector = detector;
@@ -158,14 +185,6 @@ public class Ansi {
             return true;
         }
     }
-
-    private static final InheritableThreadLocal<Boolean> holder = new InheritableThreadLocal<Boolean>()
-    {
-        @Override
-        protected Boolean initialValue() {
-            return isDetected();
-        }
-    };
 
     public static void setEnabled(final boolean flag) {
         holder.set(flag);
@@ -313,26 +332,6 @@ public class Ansi {
             return this;
         }
     }
-
-	private final StringBuilder builder;
-	private final ArrayList<Integer> attributeOptions = new ArrayList<Integer>(5);
-	
-	public Ansi() {
-		this(new StringBuilder());
-	}
-
-	public Ansi(Ansi parent) {
-	    this(new StringBuilder(parent.builder));
-	    attributeOptions.addAll(parent.attributeOptions);
-	}
-
-    public Ansi(int size) {
-		this(new StringBuilder(size));
-	}
-
-    public Ansi(StringBuilder builder) {
-		this.builder = builder;
-	}
 
 	public static Ansi ansi(StringBuilder builder) {
 		return new Ansi(builder);

--- a/jansi/src/main/java/org/fusesource/jansi/AnsiOutputStream.java
+++ b/jansi/src/main/java/org/fusesource/jansi/AnsiOutputStream.java
@@ -40,18 +40,41 @@ import java.util.ArrayList;
  */
 public class AnsiOutputStream extends FilterOutputStream {
 
-    public static final byte [] REST_CODE = resetCode();
+	public static final byte [] REST_CODE = resetCode();
 
-	public AnsiOutputStream(OutputStream os) {
-		super(os);
-	}
+	protected static final int ERASE_SCREEN_TO_END=0;
+	protected static final int ERASE_SCREEN_TO_BEGINING=1;
+	protected static final int ERASE_SCREEN=2;
+	protected static final int ERASE_LINE_TO_END=0;
+	protected static final int ERASE_LINE_TO_BEGINING=1;
+	protected static final int ERASE_LINE=2;
 
-	private  final static int MAX_ESCAPE_SEQUENCE_LENGTH=100;
-	private byte buffer[] = new byte[MAX_ESCAPE_SEQUENCE_LENGTH];
-	private int pos=0;
-	private int startOfValue;
-	private final ArrayList<Object> options = new ArrayList<Object>();
+	protected static final int ATTRIBUTE_INTENSITY_BOLD 	= 1; // 	Intensity: Bold
+	protected static final int ATTRIBUTE_INTENSITY_FAINT 	= 2; // 	Intensity; Faint 	not widely supported
+	protected static final int ATTRIBUTE_ITALIC 			= 3; // 	Italic; on 	not widely supported. Sometimes treated as inverse.
+	protected static final int ATTRIBUTE_UNDERLINE 			= 4; // 	Underline; Single
+	protected static final int ATTRIBUTE_BLINK_SLOW 		= 5; // 	Blink; Slow 	less than 150 per minute
+	protected static final int ATTRIBUTE_BLINK_FAST 		= 6; // 	Blink; Rapid 	MS-DOS ANSI.SYS; 150 per minute or more
+	protected static final int ATTRIBUTE_NEGATIVE_ON 		= 7; // 	Image; Negative 	inverse or reverse; swap foreground and background
+	protected static final int ATTRIBUTE_CONCEAL_ON 		= 8; // 	Conceal on
+	protected static final int ATTRIBUTE_UNDERLINE_DOUBLE 	= 21; // 	Underline; Double 	not widely supported
+	protected static final int ATTRIBUTE_INTENSITY_NORMAL 	= 22; // 	Intensity; Normal 	not bold and not faint
+	protected static final int ATTRIBUTE_UNDERLINE_OFF 		= 24; // 	Underline; None
+	protected static final int ATTRIBUTE_BLINK_OFF 			= 25; // 	Blink; off
+	protected static final int ATTRIBUTE_NEGATIVE_OFF = 27; // 	Image; Positive
+	protected static final int ATTRIBUTE_CONCEAL_OFF 		= 28; // 	Reveal 	conceal off
 
+	protected static final int BLACK 	= 0;
+	protected static final int RED 		= 1;
+	protected static final int GREEN 	= 2;
+	protected static final int YELLOW 	= 3;
+	protected static final int BLUE 	= 4;
+	protected static final int MAGENTA 	= 5;
+	protected static final int CYAN 	= 6;
+	protected static final int WHITE 	= 7;
+
+
+	private static final int MAX_ESCAPE_SEQUENCE_LENGTH=100;
 	private static final int LOOKING_FOR_FIRST_ESC_CHAR = 0;
 	private static final int LOOKING_FOR_SECOND_ESC_CHAR = 1;
 	private static final int LOOKING_FOR_NEXT_ARG = 2;
@@ -61,14 +84,22 @@ public class AnsiOutputStream extends FilterOutputStream {
 	private static final int LOOKING_FOR_OSC_COMMAND_END = 6;
 	private static final int LOOKING_FOR_OSC_PARAM = 7;
 	private static final int LOOKING_FOR_ST = 8;
-
-	int state = LOOKING_FOR_FIRST_ESC_CHAR;
-	
 	private static final int FIRST_ESC_CHAR = 27;
 	private static final int SECOND_ESC_CHAR = '[';
 	private static final int SECOND_OSC_CHAR = ']';
 	private static final int BEL = 7;
 	private static final int SECOND_ST_CHAR = '\\';
+
+	private final ArrayList<Object> options = new ArrayList<Object>();
+	int state = LOOKING_FOR_FIRST_ESC_CHAR;
+	private byte buffer[] = new byte[MAX_ESCAPE_SEQUENCE_LENGTH];
+	private int pos=0;
+	private int startOfValue;
+
+
+	public AnsiOutputStream(OutputStream os) {
+		super(os);
+	}
 
 	// TODO: implement to get perf boost: public void write(byte[] b, int off, int len)
 	
@@ -364,46 +395,14 @@ public class AnsiOutputStream extends FilterOutputStream {
 	protected void processScrollUp(int optionInt) throws IOException {
 	}
 
-	protected static final int ERASE_SCREEN_TO_END=0;
-	protected static final int ERASE_SCREEN_TO_BEGINING=1;
-	protected static final int ERASE_SCREEN=2;
-	
 	protected void processEraseScreen(int eraseOption) throws IOException {
 	}
 
-	protected static final int ERASE_LINE_TO_END=0;
-	protected static final int ERASE_LINE_TO_BEGINING=1;
-	protected static final int ERASE_LINE=2;
-	
 	protected void processEraseLine(int eraseOption) throws IOException {
 	}
 
-	protected static final int ATTRIBUTE_INTENSITY_BOLD 	= 1; // 	Intensity: Bold 	
-	protected static final int ATTRIBUTE_INTENSITY_FAINT 	= 2; // 	Intensity; Faint 	not widely supported
-	protected static final int ATTRIBUTE_ITALIC 			= 3; // 	Italic; on 	not widely supported. Sometimes treated as inverse.
-	protected static final int ATTRIBUTE_UNDERLINE 			= 4; // 	Underline; Single 	
-	protected static final int ATTRIBUTE_BLINK_SLOW 		= 5; // 	Blink; Slow 	less than 150 per minute
-	protected static final int ATTRIBUTE_BLINK_FAST 		= 6; // 	Blink; Rapid 	MS-DOS ANSI.SYS; 150 per minute or more
-	protected static final int ATTRIBUTE_NEGATIVE_ON 		= 7; // 	Image; Negative 	inverse or reverse; swap foreground and background
-	protected static final int ATTRIBUTE_CONCEAL_ON 		= 8; // 	Conceal on
-	protected static final int ATTRIBUTE_UNDERLINE_DOUBLE 	= 21; // 	Underline; Double 	not widely supported
-	protected static final int ATTRIBUTE_INTENSITY_NORMAL 	= 22; // 	Intensity; Normal 	not bold and not faint
-	protected static final int ATTRIBUTE_UNDERLINE_OFF 		= 24; // 	Underline; None 	
-	protected static final int ATTRIBUTE_BLINK_OFF 			= 25; // 	Blink; off 	
-	protected static final int ATTRIBUTE_NEGATIVE_Off 		= 27; // 	Image; Positive 	
-	protected static final int ATTRIBUTE_CONCEAL_OFF 		= 28; // 	Reveal 	conceal off
-
 	protected void processSetAttribute(int attribute) throws IOException {
 	}
-
-	protected static final int BLACK 	= 0;
-	protected static final int RED 		= 1;
-	protected static final int GREEN 	= 2;
-	protected static final int YELLOW 	= 3;
-	protected static final int BLUE 	= 4;
-	protected static final int MAGENTA 	= 5;
-	protected static final int CYAN 	= 6;
-	protected static final int WHITE 	= 7;
 
 	protected void processSetForegroundColor(int color) throws IOException {
 		processSetForegroundColor(color, false);

--- a/jansi/src/main/java/org/fusesource/jansi/HtmlAnsiOutputStream.java
+++ b/jansi/src/main/java/org/fusesource/jansi/HtmlAnsiOutputStream.java
@@ -22,20 +22,10 @@ import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.fusesource.jansi.AnsiOutputStream;
-
 /**
  * @author <a href="http://code.dblock.org">Daniel Doubrovkine</a>
  */
 public class HtmlAnsiOutputStream extends AnsiOutputStream {
-	
-	private boolean concealOn = false;
-
-	@Override
-	public void close() throws IOException {
-		closeAttributes();
-		super.close();
-	}
 
 	private static final String ANSI_COLOR_MAP[] = { "black", "red",
 			"green", "yellow", "blue", "magenta", "cyan", "white", };
@@ -44,12 +34,19 @@ public class HtmlAnsiOutputStream extends AnsiOutputStream {
 	private static final byte[] BYTES_AMP = "&amp;".getBytes();
 	private static final byte[] BYTES_LT = "&lt;".getBytes();
 	private static final byte[] BYTES_GT = "&gt;".getBytes();
-	
+
+	private List<String> closingAttributes = new ArrayList<String>();
+	private boolean concealOn = false;
+
 	public HtmlAnsiOutputStream(OutputStream os) {
 		super(os);
 	}
 
-	private List<String> closingAttributes = new ArrayList<String>();
+	@Override
+	public void close() throws IOException {
+		closeAttributes();
+		super.close();
+	}
 
 	private void write(String s) throws IOException {
 		super.out.write(s.getBytes());
@@ -112,7 +109,7 @@ public class HtmlAnsiOutputStream extends AnsiOutputStream {
 			break;
 		case ATTRIBUTE_NEGATIVE_ON:
 			break;
-		case ATTRIBUTE_NEGATIVE_Off:
+		case ATTRIBUTE_NEGATIVE_OFF:
 			break;
 		}
 	}

--- a/jansi/src/main/java/org/fusesource/jansi/WindowsAnsiOutputStream.java
+++ b/jansi/src/main/java/org/fusesource/jansi/WindowsAnsiOutputStream.java
@@ -291,7 +291,7 @@ public final class WindowsAnsiOutputStream extends AnsiOutputStream {
 				negative = true;
 				applyAttribute();
 				break;
-			case ATTRIBUTE_NEGATIVE_Off:
+			case ATTRIBUTE_NEGATIVE_OFF:
 				negative = false;
 				applyAttribute();
 				break;


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1213
Please let me know if you have any questions.
George Kankava
