### PR TITLE
Multiple code improvements - squid:SwitchLastCaseIsDefaultCheck, squid:S1192, squid:S1149

### DIFF
--- a/jansi/src/main/java/org/fusesource/jansi/Ansi.java
+++ b/jansi/src/main/java/org/fusesource/jansi/Ansi.java
@@ -639,6 +639,12 @@ public class Ansi {
 		return this;
 	}
 
+	public Ansi a(StringBuilder value) {
+		flushAttributes();
+		builder.append(value);
+		return this;
+	}
+
 	public Ansi a(StringBuffer value) {
 		flushAttributes();
 		builder.append(value);

--- a/jansi/src/main/java/org/fusesource/jansi/AnsiOutputStream.java
+++ b/jansi/src/main/java/org/fusesource/jansi/AnsiOutputStream.java
@@ -41,6 +41,7 @@ import java.util.ArrayList;
 public class AnsiOutputStream extends FilterOutputStream {
 
     public static final byte [] REST_CODE = resetCode();
+	public static final String UTF_8 = "UTF-8";
 
 	public AnsiOutputStream(OutputStream os) {
 		super(os);
@@ -118,7 +119,7 @@ public class AnsiOutputStream extends FilterOutputStream {
 		case LOOKING_FOR_INT_ARG_END:
 			buffer[pos++] = (byte)data;
 			if( !('0' <= data && data <= '9') ) {
-				String strValue = new String(buffer, startOfValue, (pos-1)-startOfValue, "UTF-8");
+				String strValue = new String(buffer, startOfValue, (pos-1)-startOfValue, UTF_8);
 				Integer value = new Integer(strValue);
 				options.add(value);
 				if( data == ';' ) {
@@ -132,7 +133,7 @@ public class AnsiOutputStream extends FilterOutputStream {
 		case LOOKING_FOR_STR_ARG_END:
 			buffer[pos++] = (byte)data;
 			if( '"' != data ) {
-				String value = new String(buffer, startOfValue, (pos-1)-startOfValue, "UTF-8");
+				String value = new String(buffer, startOfValue, (pos-1)-startOfValue, UTF_8);
 				options.add(value);
 				if( data == ';' ) {
 					state = LOOKING_FOR_NEXT_ARG;
@@ -155,7 +156,7 @@ public class AnsiOutputStream extends FilterOutputStream {
 		case LOOKING_FOR_OSC_COMMAND_END:
 			buffer[pos++] = (byte)data;
 			if ( ';' == data ) {
-				String strValue = new String(buffer, startOfValue, (pos-1)-startOfValue, "UTF-8");
+				String strValue = new String(buffer, startOfValue, (pos-1)-startOfValue, UTF_8);
 				Integer value = new Integer(strValue);
 				options.add(value);
 				startOfValue=pos;
@@ -171,7 +172,7 @@ public class AnsiOutputStream extends FilterOutputStream {
 		case LOOKING_FOR_OSC_PARAM:
 			buffer[pos++] = (byte)data;
 			if ( BEL == data ) {
-				String value = new String(buffer, startOfValue, (pos-1)-startOfValue, "UTF-8");
+				String value = new String(buffer, startOfValue, (pos-1)-startOfValue, UTF_8);
 				options.add(value);
 				reset( processOperatingSystemCommand(options) );
 			} else if ( FIRST_ESC_CHAR == data ) {
@@ -184,12 +185,14 @@ public class AnsiOutputStream extends FilterOutputStream {
 		case LOOKING_FOR_ST:
 			buffer[pos++] = (byte)data;
 			if ( SECOND_ST_CHAR == data ) {
-				String value = new String(buffer, startOfValue, (pos-2)-startOfValue, "UTF-8");
+				String value = new String(buffer, startOfValue, (pos-2)-startOfValue, UTF_8);
 				options.add(value);
 				reset( processOperatingSystemCommand(options) );
 			} else {
 				state = LOOKING_FOR_OSC_PARAM;
 			}
+			break;
+		default:
 			break;
 		}
 		
@@ -510,7 +513,7 @@ public class AnsiOutputStream extends FilterOutputStream {
 	
     static private byte[] resetCode() {
         try {
-            return new Ansi().reset().toString().getBytes("UTF-8");
+            return new Ansi().reset().toString().getBytes(UTF_8);
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException(e);
         }

--- a/jansi/src/main/java/org/fusesource/jansi/AnsiRenderer.java
+++ b/jansi/src/main/java/org/fusesource/jansi/AnsiRenderer.java
@@ -61,7 +61,7 @@ public class AnsiRenderer
     private AnsiRenderer() {}
 
     static public String render(final String input) throws IllegalArgumentException {
-        StringBuffer buff = new StringBuffer();
+        StringBuilder builder = new StringBuilder();
 
         int i = 0;
         int j, k;
@@ -73,12 +73,12 @@ public class AnsiRenderer
                     return input;
                 }
                 else {
-                    buff.append(input.substring(i, input.length()));
-                    return buff.toString();
+                    builder.append(input.substring(i, input.length()));
+                    return builder.toString();
                 }
             }
             else {
-                buff.append(input.substring(i, j));
+                builder.append(input.substring(i, j));
                 k = input.indexOf(END_TOKEN, j);
 
                 if (k == -1) {
@@ -94,7 +94,7 @@ public class AnsiRenderer
                     }
                     String replacement = render(items[1], items[0].split(CODE_LIST_SEPARATOR));
 
-                    buff.append(replacement);
+                    builder.append(replacement);
 
                     i = k + END_TOKEN_LEN;
                 }

--- a/jansi/src/test/java/org/fusesource/jansi/AnsiRendererTest.java
+++ b/jansi/src/test/java/org/fusesource/jansi/AnsiRendererTest.java
@@ -32,6 +32,9 @@ import static org.junit.Assert.*;
  */
 public class AnsiRendererTest
 {
+
+    public static final String FOO_BAR_BAZ = "foo bar baz";
+
     @Before
     public void setUp() {
         Ansi.setEnabled(true);
@@ -73,9 +76,9 @@ public class AnsiRendererTest
         String str = render("@|bold,red foo bar baz|@ ick @|bold,red foo bar baz|@");
         System.out.println(str);
         assertEquals(ansi()
-                .a(INTENSITY_BOLD).fg(RED).a("foo bar baz").reset()
+                .a(INTENSITY_BOLD).fg(RED).a(FOO_BAR_BAZ).reset()
                 .a(" ick ")
-                .a(INTENSITY_BOLD).fg(RED).a("foo bar baz").reset()
+                .a(INTENSITY_BOLD).fg(RED).a(FOO_BAR_BAZ).reset()
                 .toString(), str);
     }
     


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:SwitchLastCaseIsDefaultCheck - "switch" statements should end with a "default" clause.
squid:S1192 - String literals should not be duplicated.
squid:S1149 - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:SwitchLastCaseIsDefaultCheck
https://dev.eclipse.org/sonar/rules/show/squid:S1192
https://dev.eclipse.org/sonar/rules/show/squid:S1149
Please let me know if you have any questions.
George Kankava
