### PR TITLE
Deal with UnsatisfiedLinkError

### DIFF
--- a/jansi/src/main/java/org/fusesource/jansi/AnsiConsole.java
+++ b/jansi/src/main/java/org/fusesource/jansi/AnsiConsole.java
@@ -38,7 +38,7 @@ public class AnsiConsole {
     public static final PrintStream out = new PrintStream( wrapOutputStream( system_out ) );
 
     public static final PrintStream system_err = System.err;
-    public static final PrintStream err = new PrintStream( wrapOutputStream( system_err, STDERR_FILENO ) );
+    public static final PrintStream err = new PrintStream( wrapErrorOutputStream( system_err ) );
 
     private static int installed;
 
@@ -46,7 +46,19 @@ public class AnsiConsole {
     }
 
     public static OutputStream wrapOutputStream(final OutputStream stream) {
-        return wrapOutputStream(stream, STDOUT_FILENO);
+        try {
+            return wrapOutputStream(stream, STDOUT_FILENO);
+        } catch (Throwable ignore) {
+            return wrapOutputStream(stream, 0);
+        }
+    }
+
+    public static OutputStream wrapErrorOutputStream(final OutputStream stream) {
+        try {
+            return wrapOutputStream(stream, STDERR_FILENO);
+        } catch (Throwable ignore) {
+            return wrapOutputStream(stream, 0);
+        }
     }
 
     public static OutputStream wrapOutputStream(final OutputStream stream, int fileno) {


### PR DESCRIPTION
When trying to start Karaf under Solaris or ARM (raspberry), it hangs with an `UnsatisifedLinkError`. This error is caused by the fact the bundle `jline-2.14.2.jar` contains and uses classes and native libraries from `jansi`. The native library is obviously not essentially required on Unix-style systems, and the `jansi` code already tries to handle the absence of a native library, but still fails at class initialization.

It would be great to do a `jansi` release and include it in `jline` in order to update and fix in Karaf.