### PR TITLE
Avoid `WindowsAnsiOutputStream.processCursorDown` overflow on Y axis

### DIFF
--- a/jansi/src/main/java/org/fusesource/jansi/WindowsAnsiOutputStream.java
+++ b/jansi/src/main/java/org/fusesource/jansi/WindowsAnsiOutputStream.java
@@ -213,7 +213,7 @@ public final class WindowsAnsiOutputStream extends AnsiOutputStream {
     @Override
     protected void processCursorDown(int count) throws IOException {
         getConsoleInfo();
-        info.cursorPosition.y = (short) Math.min(info.size.y, info.cursorPosition.y + count);
+        info.cursorPosition.y = (short) Math.min(Math.max(0, info.size.y - 1), info.cursorPosition.y + count);
         applyCursorPosition();
     }
 


### PR DESCRIPTION
See https://github.com/fusesource/jansi/issues/69 for information on this PR and [this comment](https://github.com/gradle/gradle/issues/882#issuecomment-270267902) for the reason behind the fix.