### PR TITLE
use scm-publish plugin to deploy site to gh-pages

### DIFF
--- a/jansi-website/pom.xml
+++ b/jansi-website/pom.xml
@@ -34,6 +34,13 @@
     <netbeans.hint.deploy.server>Tomcat60</netbeans.hint.deploy.server>
   </properties>
 
+  <distributionManagement>
+    <site>
+      <id>jansi-gh-pages</id>
+      <url>scm:git:https://github.com/fusesource/jansi.git</url>
+    </site>
+  </distributionManagement>
+
   <dependencies>
 
     <dependency>
@@ -142,8 +149,6 @@
         
         <configuration>
           <webappDirectory>${basedir}/src</webappDirectory>
-          <remoteServerId>website.fusesource.org</remoteServerId>
-          <remoteServerUrl>dav:http://fusesource.com/forge/dav/${forge-project-id}/versions/${project.version}/website/</remoteServerUrl>
         </configuration>
         
         <executions>
@@ -154,15 +159,26 @@
             </goals>
             <phase>package</phase>
           </execution>
-          <execution>
-            <id>deploy</id>
-            <goals>
-              <goal>deploy</goal>
-            </goals>
-            <phase>deploy</phase>
-          </execution> 
         </executions>
-        
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-scm-publish-plugin</artifactId>
+        <version>1.1</version>
+        <configuration>
+          <scmBranch>gh-pages</scmBranch>
+          <content>${project.build.directory}/sitegen</content>
+        </configuration>
+        <executions>
+          <execution>
+            <id>gh-pages</id>
+            <goals>
+              <goal>publish-scm</goal>
+            </goals>
+            <phase>install</phase>
+          </execution>
+        </executions>
       </plugin>
 
       <plugin>
@@ -187,7 +203,6 @@
             </systemProperties>
             <scanIntervalSeconds>0</scanIntervalSeconds>
           </configuration>
-        
       </plugin>
 
       <plugin>

--- a/jansi-website/src/community/site.page
+++ b/jansi-website/src/community/site.page
@@ -44,7 +44,7 @@ How the website works
     also built using Maven so, you would
 
         cd ${project_id}-website
-        mvn install
+        mvn package
 
     If you want to edit the files in your text editor and be able to
     immediately see the site re-rendered in a browser then use
@@ -62,22 +62,11 @@ How the website works
 .right
   :markdown
   
-    The site is automatically deployed by the CI builds, so you can
-    simply wait for the changes to be automatically pushed to the project
-    site.
+#    The site is automatically deployed by the CI builds, so you can
+#    simply wait for the changes to be automatically pushed to the project
+#    site.
     
-    You can manually deploy the site using Maven:
+    The site is deployed through GitHub gh-pages branch: you can deploy the site using Maven:
     
-        mvn deploy
-
-    Since deployment to our webserver requires proper authorization,
-    you will need to add an entry to your ~/.m2/settings.xml file simlilar
-    to:
+        mvn install
     
-    {pygmentize:: xml}
-    <server>
-      <id>${project_id}-website</id>
-      <username>xxxx</username>
-      <password>xxxxx</password>
-    </server>
-    {pygmentize}


### PR DESCRIPTION
I attached to scm-publish:publish-scm goal to install phase to avoid deploy since it also deploys pom.xml to ossrh repository, but the phase can of course be changed