### PR TITLE
Filter out escape sequence 'character set' select

### DIFF
--- a/jansi/src/main/java/org/fusesource/jansi/AnsiOutputStream.java
+++ b/jansi/src/main/java/org/fusesource/jansi/AnsiOutputStream.java
@@ -64,6 +64,7 @@ public class AnsiOutputStream extends FilterOutputStream {
     private static final int LOOKING_FOR_OSC_COMMAND_END = 6;
     private static final int LOOKING_FOR_OSC_PARAM = 7;
     private static final int LOOKING_FOR_ST = 8;
+    private static final int LOOKING_FOR_CHARSET = 9;
 
     int state = LOOKING_FOR_FIRST_ESC_CHAR;
 
@@ -72,6 +73,8 @@ public class AnsiOutputStream extends FilterOutputStream {
     private static final int SECOND_OSC_CHAR = ']';
     private static final int BEL = 7;
     private static final int SECOND_ST_CHAR = '\\';
+    private static final int SECOND_CHARSET0_CHAR = '(';
+    private static final int SECOND_CHARSET1_CHAR = ')';
 
     @Override
     public synchronized void write(int data) throws IOException {
@@ -91,6 +94,12 @@ public class AnsiOutputStream extends FilterOutputStream {
                     state = LOOKING_FOR_NEXT_ARG;
                 } else if (data == SECOND_OSC_CHAR) {
                     state = LOOKING_FOR_OSC_COMMAND;
+                } else if (data == SECOND_CHARSET0_CHAR) {
+                    options.add(new Integer('0'));
+                    state = LOOKING_FOR_CHARSET;
+                } else if (data == SECOND_CHARSET1_CHAR) {
+                    options.add(new Integer('1'));
+                    state = LOOKING_FOR_CHARSET;
                 } else {
                     reset(false);
                 }
@@ -192,6 +201,11 @@ public class AnsiOutputStream extends FilterOutputStream {
                 } else {
                     state = LOOKING_FOR_OSC_PARAM;
                 }
+                break;
+
+            case LOOKING_FOR_CHARSET:
+                options.add(new Character((char) data));
+                reset(processCharsetSelect(options));
                 break;
         }
 
@@ -729,6 +743,21 @@ public class AnsiOutputStream extends FilterOutputStream {
      * @param param
      */
     protected void processUnknownOperatingSystemCommand(int command, String param) {
+    }
+
+    /**
+     * Process character set sequence.
+     * @param options
+     * @return true if the charcter set select command was processed.
+     */
+    private boolean processCharsetSelect(ArrayList<Object> options) throws IOException {
+        int set = optionInt(options, 0);
+        char seq = ((Character) options.get(1)).charValue();
+        processCharsetSelect(set, seq);
+        return true;
+    }
+
+    protected void processCharsetSelect(int set, char seq) {
     }
 
     private int optionInt(ArrayList<Object> options, int index) {

--- a/jansi/src/test/java/org/fusesource/jansi/HtmlAnsiOutputStreamTest.java
+++ b/jansi/src/test/java/org/fusesource/jansi/HtmlAnsiOutputStreamTest.java
@@ -76,6 +76,12 @@ public class HtmlAnsiOutputStreamTest {
                 colorize("[1m\u3053\u3093\u306b\u3061\u306f"));
     }
 
+    @Test
+    public void testResetCharacterSet() throws IOException {
+        assertEquals(colorize("(\033(0)"), "()");
+        assertEquals(colorize("(\033)0)"), "()");
+    }
+
     private String colorize(String text) throws IOException {
         ByteArrayOutputStream os = new ByteArrayOutputStream();
         HtmlAnsiOutputStream hos = new HtmlAnsiOutputStream(os);


### PR DESCRIPTION
Some terminals (xterm) supports two different 'character sets' ('G0' and
'G1'), which can be switched with 'SI' (shift in, '\017') and 'SO'
(shift out, '\016'). Each character set can be configured separately
and can be chosen from a list of pre-defined sets like 'ASCII Set' and
'Special Graphics'.

Running `TERM=xterm tput sgr0` to reset the terminal returns an escape
sequence starting with 'ESC ( 0', which selects the 'ASCII Set' for
'G0'. This currently is not understood by the Jenkins AnsiColor plugin.

Filter out those sequences, as they otherwise clutter the output.

<https://www.in-ulm.de/~mascheck/various/alternate_charset/> has a nice
description for characters sets

This is issue <https://github.com/fusesource/jansi/issues/29>, a
upstream port of <https://issues.jenkins-ci.org/browse/JENKINS-24387>

This fixes #29 