### PR TITLE
Correct support for the bright colors on windows - regression fix

### DIFF
--- a/jansi/src/main/java/org/fusesource/jansi/WindowsAnsiOutputStream.java
+++ b/jansi/src/main/java/org/fusesource/jansi/WindowsAnsiOutputStream.java
@@ -244,14 +244,18 @@ public final class WindowsAnsiOutputStream extends AnsiOutputStream {
     @Override
     protected void processSetForegroundColor(int color, boolean bright) throws IOException {
         info.attributes = (short) ((info.attributes & ~0x0007) | ANSI_FOREGROUND_COLOR_MAP[color]);
-        info.attributes = (short) ((info.attributes & ~FOREGROUND_INTENSITY) | (bright ? FOREGROUND_INTENSITY : 0));
+        if (bright) {
+            info.attributes |= FOREGROUND_INTENSITY;
+        }
         applyAttribute();
     }
 
     @Override
     protected void processSetBackgroundColor(int color, boolean bright) throws IOException {
         info.attributes = (short) ((info.attributes & ~0x0070) | ANSI_BACKGROUND_COLOR_MAP[color]);
-        info.attributes = (short) ((info.attributes & ~BACKGROUND_INTENSITY) | (bright ? BACKGROUND_INTENSITY : 0));
+        if (bright) {
+            info.attributes |= BACKGROUND_INTENSITY;
+        }
         applyAttribute();
     }
 


### PR DESCRIPTION
Fix regression issue introduced in Jansi 1.16.

The escape sequence **ESC[1;30m** (change to bright black foreground) cannot be rendered correctly since version 1.16 due to the second rendition parameter **30** overwrite the change made by the first parameter **1**, resulting incorrectly in normal black.

May also fix issue #94.