### PR TITLE
Fix Thread test to run test in additional thread

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: java
+
+cache:
+  directories:
+    - '$HOME/.m2/repository'
+    - '$HOME/.sonar/cache'

--- a/jansi/src/main/java/org/fusesource/jansi/AnsiMain.java
+++ b/jansi/src/main/java/org/fusesource/jansi/AnsiMain.java
@@ -183,6 +183,10 @@ public class AnsiMain {
             s.print(" " + ansi().bold().fg(c) + c + ansi().reset());
         }
         s.println();
+
+        s.println();
+        s.println(ansi().fg(Ansi.Color.GREEN) + "More info: http://fusesource.github.io/jansi/" + ansi().reset());
+        s.println();
     }
 
     private static String getPomPropertiesVersion(String path) throws IOException {

--- a/jansi/src/test/java/org/fusesource/jansi/AnsiTest.java
+++ b/jansi/src/test/java/org/fusesource/jansi/AnsiTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 the original author(s).
+ * Copyright (C) 2009-2018 the original author(s).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package org.fusesource.jansi;
 import org.fusesource.jansi.Ansi.Color;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 /**
  * Tests for the {@link Ansi} class.
@@ -27,26 +27,42 @@ import static org.junit.Assert.assertEquals;
  */
 public class AnsiTest {
     @Test
-    public void testSetEnabled() throws Exception {
+    public void testSetEnabled() throws InterruptedException {
+        boolean status = Ansi.isEnabled();
+
         Ansi.setEnabled(false);
-        new Thread() {
+        Thread threadDisabled = new Thread() {
             @Override
             public void run() {
-                assertEquals(false, Ansi.isEnabled());
+                System.out.println(Ansi.ansi().fgRed().a("ANSI disabled").reset());
+                assertFalse( Ansi.isEnabled() );
             }
-        }.run();
+        };
 
         Ansi.setEnabled(true);
-        new Thread() {
+        Thread threadEnabled =new Thread() {
             @Override
             public void run() {
-                assertEquals(true, Ansi.isEnabled());
+                System.out.println(Ansi.ansi().fgBlue().a("ANSI enabled").reset());
+                assertTrue( Ansi.isEnabled() );
             }
-        }.run();
+        };
+
+        Ansi.setEnabled(false);
+        System.out.println(Ansi.ansi().fgBlue().a("Ansi test thread start").reset());
+
+        threadDisabled.start();
+        threadEnabled.start();
+
+        threadEnabled.join();
+        threadDisabled.join();
+
+        // restore orginal status
+        Ansi.setEnabled( status );
     }
 
     @Test
-    public void testClone() throws CloneNotSupportedException {
+    public void testClone() {
         Ansi ansi = Ansi.ansi().a("Some text").bg(Color.BLACK).fg(Color.WHITE);
         Ansi clone = new Ansi(ansi);
 


### PR DESCRIPTION
correct Thread().run() to Thread().start() 

corrected to restore original status before test