### PR TITLE
fix IS_CYGWIN (was not working anyway), replaced by test on env variable ConEmuANSI=ON

### DIFF
--- a/jansi/src/main/java/org/fusesource/jansi/AnsiConsole.java
+++ b/jansi/src/main/java/org/fusesource/jansi/AnsiConsole.java
@@ -48,10 +48,15 @@ public class AnsiConsole {
 
     static final boolean IS_WINDOWS = System.getProperty("os.name").toLowerCase(Locale.ENGLISH).contains("win");
 
-    static final boolean IS_CYGWIN = IS_WINDOWS
-            && System.getenv("PWD") != null
-            && System.getenv("PWD").startsWith("/")
-            && !"cygwin".equals(System.getenv("TERM"));
+    /**
+     * true if console emulator supports ANSI, according to environement variable "ConEmuANSI"
+     * This env is standard in cmder (https://cmder.net/), conemu (https://conemu.github.io), ..
+     *
+     * Notice that being inside Cygwin (bash.exe) has nothing to do with the console terminal.
+     * You can open a plain old Windows terminal (cmd.exe), then start cygwin bash.
+     */
+    static final boolean IS_CON_EMU_ANSI =
+            "ON".equals(System.getenv("ConEmuANSI"));
 
     static final boolean IS_MINGW_XTERM = IS_WINDOWS
             && System.getenv("MSYSTEM") != null
@@ -124,9 +129,10 @@ public class AnsiConsole {
             return new AnsiOutputStream(stream);
         }
 
-        if (IS_WINDOWS && !IS_CYGWIN && !IS_MINGW_XTERM) {
-
-            // On windows we know the console does not interpret ANSI codes..
+        if (IS_WINDOWS && !IS_CON_EMU_ANSI && !IS_MINGW_XTERM) {
+            // On windows, when using default terminal (cmd.exe or power shell)
+            // but not special console emulator (cmder or conemu),
+            // we know the console does not interpret ANSI codes..
             try {
                 jansiOutputType = JansiOutputType.WINDOWS;
                 return new WindowsAnsiOutputStream(stream, fileno == STDOUT_FILENO);
@@ -202,9 +208,10 @@ public class AnsiConsole {
             return new AnsiPrintStream(ps);
         }
 
-        if (IS_WINDOWS && !IS_CYGWIN && !IS_MINGW_XTERM) {
-
-            // On windows we know the console does not interpret ANSI codes..
+        if (IS_WINDOWS && !IS_CON_EMU_ANSI && !IS_MINGW_XTERM) {
+            // On windows, when using default terminal (cmd.exe or power shell)
+            // but not special console emulator (cmder or conemu),
+            // we know the console does not interpret ANSI codes..
             try {
                 jansiOutputType = JansiOutputType.WINDOWS;
                 return new WindowsAnsiPrintStream(ps, fileno == STDOUT_FILENO);

--- a/jansi/src/main/java/org/fusesource/jansi/AnsiMain.java
+++ b/jansi/src/main/java/org/fusesource/jansi/AnsiMain.java
@@ -87,8 +87,8 @@ public class AnsiMain {
 
         System.out.println("IS_WINDOWS: " + AnsiConsole.IS_WINDOWS);
         if (AnsiConsole.IS_WINDOWS) {
-            System.out.println("IS_CYGWIN: " + AnsiConsole.IS_CYGWIN);
             System.out.println("IS_MINGW_XTERM: " + AnsiConsole.IS_MINGW_XTERM);
+            System.out.println("IS_CON_EMU_ANSI: " + AnsiConsole.IS_CON_EMU_ANSI);
         }
 
         System.out.println();


### PR DESCRIPTION
…was typo "!"
IS_CYGWIN = ... !"cygwin".equals(System.getenv("TERM")
instead of
IS_CYGWIN = ... "cygwin".equals(System.getenv("TERM")

notice that in a windows cmd.exe console, the jansi mode "WINDOWS" works fine ... this is independent of the fact that the process "bash.exe" from cygwin is running

notice also that on windows, a very frequent usage is to use cmder console emulator (https://cmder.net/) + cygwin
The cmder console define several environment variables, including
ConEmuANSI="ON"
which could be tested to use the standard ANSI mode of jansi
