### PR TITLE
use buffer to reduce number of flush() .. (this also needed to use Writer instead of OutputStream/PrintStream)

### DIFF
--- a/jansi/src/main/java/org/fusesource/jansi/impl/FlushBufferedOutputStream.java
+++ b/jansi/src/main/java/org/fusesource/jansi/impl/FlushBufferedOutputStream.java
@@ -1,0 +1,64 @@
+package org.fusesource.jansi.impl;
+
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * buffered java.io.OutputStream with flushBuffer()
+ *
+ * similar to java.io.ByteArrayOutputStream / BufferedOutputSteam,
+ * and with flushBuffer() that flush the buffer to the underlying output
+ * without calling flush() on the underlying writer.
+ */
+public class FlushBufferedOutputStream extends FilterOutputStream {
+
+    protected byte buf[];
+
+    protected int count;
+
+    public FlushBufferedOutputStream(OutputStream out, int size) {
+        super(out);
+        if (size <= 0) {
+            throw new IllegalArgumentException("Buffer size <= 0");
+        }
+        buf = new byte[size];
+    }
+
+    /** Flush the internal buffer */
+    public void flushBuffer() throws IOException {
+        if (count > 0) {
+            out.write(buf, 0, count);
+            count = 0;
+        }
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+        if (count >= buf.length) {
+            flushBuffer();
+        }
+        buf[count++] = (byte)b;
+    }
+
+    @Override
+    public void write(byte b[], int off, int len) throws IOException {
+        if (len >= buf.length) {
+            flushBuffer();
+            out.write(b, off, len);
+            return;
+        }
+        if (len > buf.length - count) {
+            flushBuffer();
+        }
+        System.arraycopy(b, off, buf, count, len);
+        count += len;
+    }
+
+    @Override
+    public synchronized void flush() throws IOException {
+        flushBuffer();
+        out.flush();
+    }
+
+}

--- a/jansi/src/main/java/org/fusesource/jansi/impl/FlushBufferedWriter.java
+++ b/jansi/src/main/java/org/fusesource/jansi/impl/FlushBufferedWriter.java
@@ -1,0 +1,64 @@
+package org.fusesource.jansi.impl;
+
+import java.io.FilterWriter;
+import java.io.IOException;
+import java.io.Writer;
+
+/**
+ * buffered java.io.Writer with flushBuffer()
+ *
+ * similar to java.io.BufferedWriter,
+ * and with flushBuffer() that flush the buffer to the underlying output
+ * without calling flush() on the underlying.
+ */
+public class FlushBufferedWriter extends FilterWriter {
+
+    protected char buf[];
+
+    protected int count;
+
+    public FlushBufferedWriter(Writer out, int size) {
+        super(out);
+        if (size <= 0) {
+            throw new IllegalArgumentException("Buffer size <= 0");
+        }
+        buf = new char[size];
+    }
+
+    /** Flush the internal buffer */
+    public void flushBuffer() throws IOException {
+        if (count > 0) {
+            out.write(buf, 0, count);
+            count = 0;
+        }
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+        if (count >= buf.length) {
+            flushBuffer();
+        }
+        buf[count++] = (char)b;
+    }
+
+    @Override
+    public void write(char b[], int off, int len) throws IOException {
+        if (len >= buf.length) {
+            flushBuffer();
+            out.write(b, off, len);
+            return;
+        }
+        if (len > buf.length - count) {
+            flushBuffer();
+        }
+        System.arraycopy(b, off, buf, count, len);
+        count += len;
+    }
+
+    @Override
+    public synchronized void flush() throws IOException {
+        flushBuffer();
+        out.flush();
+    }
+
+}

--- a/jansi/src/main/java/org/fusesource/jansi/impl/PrintStreamWriter.java
+++ b/jansi/src/main/java/org/fusesource/jansi/impl/PrintStreamWriter.java
@@ -1,0 +1,55 @@
+package org.fusesource.jansi.impl;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.io.Writer;
+
+/**
+ * bridge from java.io.Writer to java.io.PrintStream
+ */
+public class PrintStreamWriter extends Writer {
+
+    private final PrintStream out;
+
+    public PrintStreamWriter(PrintStream out) {
+        super();
+        this.out = out;
+    }
+
+    @Override
+    public void write(int c) throws IOException {
+        out.write(c);
+    }
+
+    @Override
+    public void write(char[] cbuf) throws IOException {
+        out.print(cbuf);
+    }
+
+    @Override
+    public void write(char[] cbuf, int off, int len) throws IOException {
+        if (off == 0 && cbuf.length == len) {
+            out.print(cbuf);
+        } else {
+            char[] copy = new char[len];
+            System.arraycopy(cbuf, off, copy, 0, len);
+            out.print(copy);
+        }
+    }
+
+    @Override
+    public void write(String str) throws IOException {
+        out.print(str);
+    }
+
+    @Override
+    public void flush() throws IOException {
+        out.flush();
+    }
+
+    @Override
+    public void close() throws IOException {
+        out.close();
+    }
+
+}


### PR DESCRIPTION
Introducing FlushBufferedWriter between the AnsiPrintSteam and the underlying stdout to reduce the number of flush()

Also introducing similar FlushBufferedOutputSteam in deprecated AnsiOutputStream

Both classes still suffer from a problem of encoding, because they use java.io.OutputStream (to write byte,byte[]) instead of java.io.Writer (to write char,char[],String,CharSequence)

This is very infortunate that in java.io.PrintStream, the class is able to format both text oriented value and byte[] as it extends from java.io.OutputStream.
For write(int) and write(int[]) methods, I pretend that the bytes should NOT be interpreted as chars, and should NOT be filtered by ansi escape code. I have HOWEVER left the feature as it was.

For print() and println() values, the class PrintStream formats values as String then encode as byte[] using OutputStreamWriter ... then using jdk-private method flushBuffer() transfers byte[] to the underlying OutputStream without flushing.  This is the same logic to overwrite in the class jansi FilterPrintStream, using the same buffer mechanism.

Fragments of jdk code for flushBuffer() is copied here is this PR to allow both proper interpretation of char encoding, then avoid to many flush() on underlying stdout.


