### PR TITLE
enhance memory usage using buffer, or avoiding alloc

### DIFF
--- a/jansi/src/main/java/org/fusesource/jansi/Ansi.java
+++ b/jansi/src/main/java/org/fusesource/jansi/Ansi.java
@@ -356,7 +356,7 @@ public class Ansi {
     private final ArrayList<Integer> attributeOptions = new ArrayList<Integer>(5);
 
     public Ansi() {
-        this(new StringBuilder());
+        this(new StringBuilder(80));
     }
 
     public Ansi(Ansi parent) {

--- a/jansi/src/main/java/org/fusesource/jansi/AnsiOutputStream.java
+++ b/jansi/src/main/java/org/fusesource/jansi/AnsiOutputStream.java
@@ -134,7 +134,7 @@ public class AnsiOutputStream extends FilterOutputStream { // expected diff with
                 buffer[pos++] = (byte) data;
                 if (!('0' <= data && data <= '9')) {
                     String strValue = new String(buffer, startOfValue, (pos - 1) - startOfValue, Charset.defaultCharset());
-                    Integer value = new Integer(strValue);
+                    Integer value = Integer.valueOf(strValue);
                     options.add(value);
                     if (data == ';') {
                         state = LOOKING_FOR_NEXT_ARG;
@@ -171,7 +171,7 @@ public class AnsiOutputStream extends FilterOutputStream { // expected diff with
                 buffer[pos++] = (byte) data;
                 if (';' == data) {
                     String strValue = new String(buffer, startOfValue, (pos - 1) - startOfValue, Charset.defaultCharset());
-                    Integer value = new Integer(strValue);
+                    Integer value = Integer.valueOf(strValue);
                     options.add(value);
                     startOfValue = pos;
                     state = LOOKING_FOR_OSC_PARAM;

--- a/jansi/src/main/java/org/fusesource/jansi/AnsiPrintStream.java
+++ b/jansi/src/main/java/org/fusesource/jansi/AnsiPrintStream.java
@@ -126,7 +126,7 @@ public class AnsiPrintStream extends FilterPrintStream { // expected diff with A
                 buffer[pos++] = (byte) data;
                 if (!('0' <= data && data <= '9')) {
                     String strValue = new String(buffer, startOfValue, (pos - 1) - startOfValue, Charset.defaultCharset());
-                    Integer value = new Integer(strValue);
+                    Integer value = Integer.valueOf(strValue);
                     options.add(value);
                     if (data == ';') {
                         state = LOOKING_FOR_NEXT_ARG;
@@ -163,7 +163,7 @@ public class AnsiPrintStream extends FilterPrintStream { // expected diff with A
                 buffer[pos++] = (byte) data;
                 if (';' == data) {
                     String strValue = new String(buffer, startOfValue, (pos - 1) - startOfValue, Charset.defaultCharset());
-                    Integer value = new Integer(strValue);
+                    Integer value = Integer.valueOf(strValue);
                     options.add(value);
                     startOfValue = pos;
                     state = LOOKING_FOR_OSC_PARAM;

--- a/jansi/src/main/java/org/fusesource/jansi/AnsiRenderer.java
+++ b/jansi/src/main/java/org/fusesource/jansi/AnsiRenderer.java
@@ -60,7 +60,7 @@ public class AnsiRenderer {
 
     public static String render(final String input) throws IllegalArgumentException {
         try {
-            return render(input, new StringBuilder()).toString();
+            return render(input, new StringBuilder(input.length())).toString();
         } catch (IOException e) {
             // Cannot happen because StringBuilder does not throw IOException
             throw new IllegalArgumentException(e);

--- a/jansi/src/main/java/org/fusesource/jansi/AnsiString.java
+++ b/jansi/src/main/java/org/fusesource/jansi/AnsiString.java
@@ -39,7 +39,7 @@ public class AnsiString
     private CharSequence chew(final CharSequence str) {
         assert str != null;
 
-        ByteArrayOutputStream buff = new ByteArrayOutputStream();
+        ByteArrayOutputStream buff = new ByteArrayOutputStream(str.length());
         AnsiOutputStream out = new AnsiOutputStream(buff);
 
         try {

--- a/jansi/src/main/java/org/fusesource/jansi/FilterPrintStream.java
+++ b/jansi/src/main/java/org/fusesource/jansi/FilterPrintStream.java
@@ -29,7 +29,12 @@ import java.io.PrintStream;
 public class FilterPrintStream extends PrintStream
 {
     private static final String NEWLINE = System.getProperty("line.separator");
+
+    private static final int TMP_STR_TO_CHAR_BUFFER_LENGTH = 400;
+
     protected final PrintStream ps;
+
+    private final char[] strToCharBuffer = new char[TMP_STR_TO_CHAR_BUFFER_LENGTH];
 
     public FilterPrintStream(PrintStream ps)
     {
@@ -103,7 +108,7 @@ public class FilterPrintStream extends PrintStream
     }
 
     private void write(String s) {
-        char[] buf = new char[s.length()];
+        char[] buf = (s.length() < strToCharBuffer.length)? strToCharBuffer : new char[s.length()];
         s.getChars(0, s.length(), buf, 0);
         write(buf);
     }
@@ -121,7 +126,12 @@ public class FilterPrintStream extends PrintStream
 
     @Override
     public void print(char c) {
-        write(String.valueOf(c));
+        // optim for: write(String.valueOf(c));
+        if (filter(c))
+        {
+            ps.print(c);
+        }
+
     }
 
     @Override


### PR DESCRIPTION
avoid so many conversions of 
char -> to String -> getChars() -> copy chars -> foreach char -> to String -> getChars ... 

also use bigger buffer... as printed log line usually got more than 50 chars.. 
not 16 as default in StringBuilder constructor (with 16 chars, you can write "Hello World !!!!" )
