### PR TITLE
Allow multiple architecture native builds

### DIFF
--- a/jansi/pom.xml
+++ b/jansi/pom.xml
@@ -46,12 +46,12 @@
          platforms -->
     <dependency>
       <groupId>org.fusesource.jansi</groupId>
-      <artifactId>jansi-windows32</artifactId>
+      <artifactId>jansi-windows32-i386</artifactId>
       <version>${jansi-native-version}</version>
     </dependency>
     <dependency>
       <groupId>org.fusesource.jansi</groupId>
-      <artifactId>jansi-windows64</artifactId>
+      <artifactId>jansi-windows64-amd64</artifactId>
       <version>${jansi-native-version}</version>
     </dependency>
     <dependency>
@@ -61,22 +61,42 @@
     </dependency>
     <dependency>
       <groupId>org.fusesource.jansi</groupId>
-      <artifactId>jansi-linux32</artifactId>
+      <artifactId>jansi-linux32-i386</artifactId>
       <version>${jansi-native-version}</version>
     </dependency>
     <dependency>
       <groupId>org.fusesource.jansi</groupId>
-      <artifactId>jansi-linux64</artifactId>
+      <artifactId>jansi-linux32-arm</artifactId>
       <version>${jansi-native-version}</version>
     </dependency>
     <dependency>
       <groupId>org.fusesource.jansi</groupId>
-      <artifactId>jansi-freebsd32</artifactId>
+      <artifactId>jansi-linux64-amd64</artifactId>
       <version>${jansi-native-version}</version>
     </dependency>
     <dependency>
       <groupId>org.fusesource.jansi</groupId>
-      <artifactId>jansi-freebsd64</artifactId>
+      <artifactId>jansi-linux64-aarch64</artifactId>
+      <version>${jansi-native-version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.fusesource.jansi</groupId>
+      <artifactId>jansi-linux64-ppc64le</artifactId>
+      <version>${jansi-native-version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.fusesource.jansi</groupId>
+      <artifactId>jansi-linux64-s390x</artifactId>
+      <version>${jansi-native-version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.fusesource.jansi</groupId>
+      <artifactId>jansi-freebsd32-i386</artifactId>
+      <version>${jansi-native-version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.fusesource.jansi</groupId>
+      <artifactId>jansi-freebsd64-amd64</artifactId>
       <version>${jansi-native-version}</version>
     </dependency>
 


### PR DESCRIPTION
HawtJNI's description of platform is insufficient to distinguish between
multiple architectures of the same operating system, such as Linux/amd64
and Linux/aarch64. Renaming these resources is necessary to create jars
which will cover all available OS/arch combinations.

Required by: https://github.com/fusesource/jansi-native/pull/18