### PR TITLE
Change to https links to address issue 170

### DIFF
--- a/src/download.page
+++ b/src/download.page
@@ -48,9 +48,9 @@ table.download tr td {
   table.download
     tr 
       td 
-        a(href="http://repo1.maven.org/maven2/org/fusesource/#{project_id}/#{project_id}/#{version}/#{project_id}-#{version}.jar") #{project_id}-#{version}.jar
+        a(href="https://repo1.maven.org/maven2/org/fusesource/#{project_id}/#{project_id}/#{version}/#{project_id}-#{version}.jar") #{project_id}-#{version}.jar
       td
-        a(href="http://repo1.maven.org/maven2/org/fusesource/#{project_id}/#{project_id}/#{version}/#{project_id}-#{version}.jar.asc") GPG Signature
+        a(href="https://repo1.maven.org/maven2/org/fusesource/#{project_id}/#{project_id}/#{version}/#{project_id}-#{version}.jar.asc") GPG Signature
     
     
 - if( !project_versions.drop(1).isEmpty )
@@ -61,9 +61,9 @@ table.download tr td {
     - for( version <- project_versions.drop(1) )
       tr 
         td 
-          a(href="http://repo1.maven.org/maven2/org/fusesource/#{project_id}/#{project_id}/#{version}/#{project_id}-#{version}.jar") #{project_id}-#{version}.jar
+          a(href="https://repo1.maven.org/maven2/org/fusesource/#{project_id}/#{project_id}/#{version}/#{project_id}-#{version}.jar") #{project_id}-#{version}.jar
         td
-          a(href="http://repo1.maven.org/maven2/org/fusesource/#{project_id}/#{project_id}/#{version}/#{project_id}-#{version}.jar.asc") GPG Signature
+          a(href="https://repo1.maven.org/maven2/org/fusesource/#{project_id}/#{project_id}/#{version}/#{project_id}-#{version}.jar.asc") GPG Signature
   
 :&markdown
   The development build source code should be directly checked out from our [source code repository](community/source.html):


### PR DESCRIPTION
Maven.org responds with a 501 now to HTTP links and wants https used instead.
https://github.com/fusesource/jansi/issues/170