### PR TITLE
Use the FreeBSD container working directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,10 +70,10 @@ mac-x86_64:
 	docker run -it --rm -v $$PWD:/workdir -e CROSS_TRIPLE=x86_64-apple-darwin multiarch/crossbuild make clean-native native OS_NAME=Mac OS_ARCH=x86_64
 
 freebsd-x86:
-	docker run -it --rm -v $$PWD:/build empterdose/freebsd-cross-build:9.3 make -C /build clean-native native CROSS_PREFIX=i386-freebsd9- OS_NAME=FreeBSD OS_ARCH=x86
+	docker run -it --rm -v $$PWD:/workdir empterdose/freebsd-cross-build:9.3 make clean-native native CROSS_PREFIX=i386-freebsd9- OS_NAME=FreeBSD OS_ARCH=x86
 
 freebsd-x86_64:
-	docker run -it --rm -v $$PWD:/build empterdose/freebsd-cross-build:9.3 make -C /build clean-native native CROSS_PREFIX=x86_64-freebsd9- OS_NAME=FreeBSD OS_ARCH=x86_64
+	docker run -it --rm -v $$PWD:/workdir empterdose/freebsd-cross-build:9.3 make clean-native native CROSS_PREFIX=x86_64-freebsd9- OS_NAME=FreeBSD OS_ARCH=x86_64
 
 #sparcv9:
 #	$(MAKE) native OS_NAME=SunOS OS_ARCH=sparcv9


### PR DESCRIPTION
I was really chuffed to find that you've been using my FreeBSD cross-build container. I built the container to meet my personal needs, but I'm happy you've been able to find use in it as well. However, I built it without much familiarity with Docker in general, and in particular, without knowledge of [the `WORKDIR` instruction](https://docs.docker.com/engine/reference/builder/#workdir). I've just updated my Dockerfile to specify a working directory, and this PR adds support for its use when building the FreeBSD natives.