### PR TITLE
Add Ansi.apply method

### DIFF
--- a/src/main/java/org/fusesource/jansi/Ansi.java
+++ b/src/main/java/org/fusesource/jansi/Ansi.java
@@ -151,6 +151,10 @@ public class Ansi implements Appendable {
         }
     }
 
+    public interface Consumer {
+        void apply(Ansi ansi);
+    }
+
     public static final String DISABLE = Ansi.class.getName() + ".disable";
 
     private static Callable<Boolean> detector = new Callable<Boolean>() {
@@ -734,6 +738,17 @@ public class Ansi implements Appendable {
     public Ansi format(String pattern, Object... args) {
         flushAttributes();
         builder.append(String.format(pattern, args));
+        return this;
+    }
+
+    /**
+     * Applies another function to this Ansi instance.
+     *
+     * @param fun the function to apply
+     * @return this Ansi instance
+     */
+    public Ansi apply(Consumer fun) {
+        fun.apply(this);
         return this;
     }
 

--- a/src/test/java/org/fusesource/jansi/AnsiTest.java
+++ b/src/test/java/org/fusesource/jansi/AnsiTest.java
@@ -52,4 +52,13 @@ public class AnsiTest {
 
         assertEquals(ansi.a("test").reset().toString(), clone.a("test").reset().toString());
     }
+
+    @Test
+    public void testApply() {
+        assertEquals("test", Ansi.ansi().apply(new Ansi.Consumer() {
+            public void apply(Ansi ansi) {
+                ansi.a("test");
+            }
+        }).toString());
+    }
 }


### PR DESCRIPTION
Adds a new method "apply" to the Ansi class. This is especially useful when used with lambdas. Applying other functions to the Ansi class is now possible without breaking out of the fluent API flow. This is best shown with the following example:

Before:
```
Ansi ansi = Ansi.ansi().fgRed();
complexFunction(ansi);
ansi.reset();
```

Now:
```
Ansi ansi = Ansi.ansi().fgRed().apply(this::complexFunction).reset();
```