### PR TITLE
Handle SGRs with multiple options

### DIFF
--- a/src/main/java/org/fusesource/jansi/io/AnsiProcessor.java
+++ b/src/main/java/org/fusesource/jansi/io/AnsiProcessor.java
@@ -128,6 +128,9 @@ public class AnsiProcessor {
                             } else if (100 <= value && value <= 107) {
                                 processSetBackgroundColor(value - 100, true);
                             } else if (value == 38 || value == 48) {
+                                if (!optionsIterator.hasNext()) {
+                                    continue;
+                                }
                                 // extended color like `esc[38;5;<index>m` or `esc[38;2;<r>;<g>;<b>m`
                                 int arg2or5 = getNextOptionInt(optionsIterator);
                                 if (arg2or5 == 2) {

--- a/src/test/java/org/fusesource/jansi/io/AnsiOutputStreamTest.java
+++ b/src/test/java/org/fusesource/jansi/io/AnsiOutputStreamTest.java
@@ -1,0 +1,22 @@
+package org.fusesource.jansi.io;
+
+import org.fusesource.jansi.AnsiColors;
+import org.fusesource.jansi.AnsiMode;
+import org.fusesource.jansi.AnsiType;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.Charset;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class AnsiOutputStreamTest {
+    @Test
+    void canHandleSgrsWithMultipleOptions() throws IOException {
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        final AnsiOutputStream ansiOutput = new AnsiOutputStream(baos, AnsiMode.Strip, null, AnsiType.Emulation, AnsiColors.TrueColor, Charset.forName("UTF-8"), null, null, false);
+        ansiOutput.write("\u001B[33mbanana_1  |\u001B[0m 19:59:14.353\u001B[0;38m [debug] Lager installed handler {lager_file_backend,\"banana.log\"} into lager_event\u001B[0m\n".getBytes());
+        assertEquals("banana_1  | 19:59:14.353 [debug] Lager installed handler {lager_file_backend,\"banana.log\"} into lager_event\n", baos.toString());
+    }
+}


### PR DESCRIPTION
Currently `jansi` doesn't handle the sequence `ESC[0;38m`. This PR fixes that and adds a test.

A similar approach has been implemented in Jenkins `ansicolor-plugin` for some time, where the issue has been brought up [by a user in a bug ticket](https://github.com/jenkinsci/ansicolor-plugin/issues/158#issuecomment-616801975).

I am not entirely sure what that sequence is supposed to do (haven't found it in any documentation) but using it in shell doesn't render any special characters/effects so I guess `jansi` should behave the same.