### PR TITLE
Add missing space in SunOS-sparcv9_CCFLAGS

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -110,7 +110,7 @@ OpenBSD-x86_64_JANSI_FLAGS  :=
 
 SunOS-sparcv9_CC        := $(CROSS_PREFIX)gcc
 SunOS-sparcv9_STRIP     := $(CROSS_PREFIX)strip
-SunOS-sparcv9_CCFLAGS   := -I$(JAVA_HOME)/include -Itarget/inc -Itarget/inc/unix -O2s-fPIC -m64 -fvisibility=hidden
+SunOS-sparcv9_CCFLAGS   := -I$(JAVA_HOME)/include -Itarget/inc -Itarget/inc/unix -O2s -fPIC -m64 -fvisibility=hidden
 SunOS-sparcv9_LINKFLAGS := -shared -static-libgcc
 SunOS-sparcv9_LIBNAME   := libjansi.so
 SunOS-sparcv9_JANSI_FLAGS  := 


### PR DESCRIPTION
@gnodet Please have a look. Just a simple oversight.