### PR TITLE
Fix invalid string input

### DIFF
--- a/src/main/java/org/fusesource/jansi/AnsiRenderer.java
+++ b/src/main/java/org/fusesource/jansi/AnsiRenderer.java
@@ -99,6 +99,11 @@ public class AnsiRenderer {
                 return target;
             }
             j += BEGIN_TOKEN_LEN;
+
+            // Check for invalid string with END_TOKEN before BEGIN_TOKEN
+            if (k < j) {
+                throw new IllegalArgumentException("Invalid input string found.");
+            }
             String spec = input.substring(j, k);
 
             String[] items = spec.split(CODE_TEXT_SEPARATOR, 2);

--- a/src/test/java/org/fusesource/jansi/AnsiRendererTest.java
+++ b/src/test/java/org/fusesource/jansi/AnsiRendererTest.java
@@ -24,6 +24,7 @@ import static org.fusesource.jansi.Ansi.Color.*;
 import static org.fusesource.jansi.AnsiRenderer.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -32,7 +33,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * @author <a href="mailto:jason@planet57.com">Jason Dillon</a>
  */
 public class AnsiRendererTest {
-
     @BeforeAll
     static void setUp() {
         Ansi.setEnabled(true);
@@ -95,7 +95,6 @@ public class AnsiRendererTest {
         assertEquals(ansi().a(INTENSITY_BOLD).a("Hello").reset().toString(), str);
     }
 
-
     @Test
     public void testRenderNothing() {
         assertEquals("foo", render("foo"));
@@ -105,6 +104,11 @@ public class AnsiRendererTest {
     public void testRenderInvalidMissingEnd() {
         String str = render("@|bold foo");
         assertEquals("@|bold foo", str);
+    }
+
+    @Test
+    public void testRenderInvalidEndBeforeStart() {
+        assertThrows(IllegalArgumentException.class, () -> render("@|@"));
     }
 
     @Test


### PR DESCRIPTION
This fixes a possible unwrapped StringIndexOutOfBoundException in src/main/java/org/fusesource/jansi/AnsiRenderer.java.

In [line 85](https://github.com/arthurscchan/jansi/blob/master/src/main/java/org/fusesource/jansi/AnsiRenderer.java#L85), [line 95](https://github.com/arthurscchan/jansi/blob/master/src/main/java/org/fusesource/jansi/AnsiRenderer.java#L95) and [line 101](https://github.com/arthurscchan/jansi/blob/master/src/main/java/org/fusesource/jansi/AnsiRenderer.java#L101) of the AnsiRenderer class. The method tries to determine the necessary index j and k for doing a substring operation on the input string. If the input string is malformed, it could cause j larger than k and result in StringIndexOutOfBoundException. For example, if the EndToken appears before the BeginToken, or there is no EndToken in the input string, then j is larger than k for sure.

This PR fixes the bug by adding a conditional check before doing the substring to ensure k is larger or equals to j. Otherwise, the input string is considered as malformed and an IllegalArgumentException is thrown.

We found this bug using fuzzing by way of OSS-Fuzz, where we recently integrated jansi (https://github.com/google/oss-fuzz/pull/10705). OSS-Fuzz is a free service run by Google for fuzzing important open source software. If you'd like to know more about this then I'm happy to go in details and also set up things so you can receive emails and detailed reports when bugs are found.
