### PR TITLE
Add module-info through moditect

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -183,6 +183,33 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.moditect</groupId>
+                <artifactId>moditect-maven-plugin</artifactId>
+                <version>1.0.0.Final</version>
+                <executions>
+                    <execution>
+                        <id>add-module-infos</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>add-module-info</goal>
+                        </goals>
+                        <configuration>
+                            <jvmVersion>9</jvmVersion>
+                            <module>
+                                <moduleInfo>
+                                    <name>org.fusesource.jansi</name>
+                                    <exports>
+                                        org.fusesource.jansi;
+                                        org.fusesource.jansi.io;
+                                    </exports>
+                                </moduleInfo>
+                            </module>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>3.0.0</version>


### PR DESCRIPTION
This PR adds the moditect maven plugin to the build. This includes a `module-info.class` in a multi-release jar.

The capability this allows is for users to use jansi with jlink without configuration. Its also just a thing that needs to happen for downstream dependencies like jline to do the same.

## Before

![jlink_fail](https://github.com/fusesource/jansi/assets/5004262/c7f8afeb-dd70-4fba-a933-a6fd052947f2)


## After

![jlink_success](https://github.com/fusesource/jansi/assets/5004262/81eef633-e3f8-447d-af9e-fda64631daeb)




