### PR TITLE
Fix FFM backend on Windows

### DIFF
--- a/src/main/java/org/fusesource/jansi/AnsiConsole.java
+++ b/src/main/java/org/fusesource/jansi/AnsiConsole.java
@@ -24,7 +24,6 @@ import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
 import java.nio.charset.UnsupportedCharsetException;
-import java.util.Locale;
 
 import org.fusesource.jansi.internal.OSInfo;
 import org.fusesource.jansi.io.AnsiOutputStream;

--- a/src/main/java/org/fusesource/jansi/AnsiConsole.java
+++ b/src/main/java/org/fusesource/jansi/AnsiConsole.java
@@ -26,6 +26,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.UnsupportedCharsetException;
 import java.util.Locale;
 
+import org.fusesource.jansi.internal.OSInfo;
 import org.fusesource.jansi.io.AnsiOutputStream;
 import org.fusesource.jansi.io.AnsiProcessor;
 import org.fusesource.jansi.io.FastBufferedOutputStream;
@@ -194,8 +195,7 @@ public class AnsiConsole {
         return w;
     }
 
-    static final boolean IS_WINDOWS =
-            System.getProperty("os.name").toLowerCase(Locale.ENGLISH).contains("win");
+    static final boolean IS_WINDOWS = OSInfo.isWindows();
 
     static final boolean IS_CYGWIN =
             IS_WINDOWS && System.getenv("PWD") != null && System.getenv("PWD").startsWith("/");

--- a/src/main/java/org/fusesource/jansi/ffm/AnsiConsoleSupportFfm.java
+++ b/src/main/java/org/fusesource/jansi/ffm/AnsiConsoleSupportFfm.java
@@ -95,5 +95,4 @@ public class AnsiConsoleSupportFfm implements AnsiConsoleSupport {
             }
         };
     }
-
 }

--- a/src/main/java/org/fusesource/jansi/ffm/AnsiConsoleSupportFfm.java
+++ b/src/main/java/org/fusesource/jansi/ffm/AnsiConsoleSupportFfm.java
@@ -18,16 +18,11 @@ package org.fusesource.jansi.ffm;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.foreign.Arena;
-import java.lang.foreign.FunctionDescriptor;
-import java.lang.foreign.GroupLayout;
-import java.lang.foreign.Linker;
-import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.VarHandle;
 
 import org.fusesource.jansi.AnsiConsoleSupport;
+import org.fusesource.jansi.internal.OSInfo;
 import org.fusesource.jansi.io.AnsiProcessor;
 
 import static org.fusesource.jansi.ffm.Kernel32.*;
@@ -40,68 +35,11 @@ public class AnsiConsoleSupportFfm implements AnsiConsoleSupport {
 
     @Override
     public CLibrary getCLibrary() {
-        return new CLibrary() {
-            private static final int TIOCGWINSZ;
-            private static final GroupLayout wsLayout;
-            private static final MethodHandle ioctl;
-            private static final VarHandle ws_col;
-            private static final MethodHandle isatty;
-
-            static {
-                String osName = System.getProperty("os.name");
-                if (osName.startsWith("Linux")) {
-                    String arch = System.getProperty("os.arch");
-                    boolean isMipsPpcOrSparc =
-                            arch.startsWith("mips") || arch.startsWith("ppc") || arch.startsWith("sparc");
-                    TIOCGWINSZ = isMipsPpcOrSparc ? 0x40087468 : 0x00005413;
-                } else if (osName.startsWith("Solaris") || osName.startsWith("SunOS")) {
-                    int _TIOC = ('T' << 8);
-                    TIOCGWINSZ = (_TIOC | 104);
-                } else if (osName.startsWith("Mac") || osName.startsWith("Darwin")) {
-                    TIOCGWINSZ = 0x40087468;
-                } else if (osName.startsWith("FreeBSD")) {
-                    TIOCGWINSZ = 0x40087468;
-                } else {
-                    throw new UnsupportedOperationException();
-                }
-
-                wsLayout = MemoryLayout.structLayout(
-                        ValueLayout.JAVA_SHORT.withName("ws_row"),
-                        ValueLayout.JAVA_SHORT.withName("ws_col"),
-                        ValueLayout.JAVA_SHORT,
-                        ValueLayout.JAVA_SHORT);
-                ws_col = wsLayout.varHandle(MemoryLayout.PathElement.groupElement("ws_col"));
-                Linker linker = Linker.nativeLinker();
-                ioctl = linker.downcallHandle(
-                        linker.defaultLookup().find("ioctl").get(),
-                        FunctionDescriptor.of(
-                                ValueLayout.JAVA_INT, ValueLayout.JAVA_INT, ValueLayout.JAVA_LONG, ValueLayout.ADDRESS),
-                        Linker.Option.firstVariadicArg(2));
-                isatty = linker.downcallHandle(
-                        linker.defaultLookup().find("isatty").get(),
-                        FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.JAVA_INT));
-            }
-
-            @Override
-            public short getTerminalWidth(int fd) {
-                try (Arena session = Arena.ofConfined()) {
-                    MemorySegment segment = session.allocate(wsLayout);
-                    int res = (int) ioctl.invoke(fd, (long) TIOCGWINSZ, segment);
-                    return (short) ws_col.get(segment);
-                } catch (Throwable e) {
-                    throw new RuntimeException("Unable to ioctl(TIOCGWINSZ)", e);
-                }
-            }
-
-            @Override
-            public int isTty(int fd) {
-                try {
-                    return (int) isatty.invoke(fd);
-                } catch (Throwable e) {
-                    throw new RuntimeException("Unable to call isatty", e);
-                }
-            }
-        };
+        if (OSInfo.isWindows()) {
+            return new WindowsCLibrary();
+        } else {
+            return new PosixCLibrary();
+        }
     }
 
     @Override
@@ -157,4 +95,5 @@ public class AnsiConsoleSupportFfm implements AnsiConsoleSupport {
             }
         };
     }
+
 }

--- a/src/main/java/org/fusesource/jansi/ffm/AnsiConsoleSupportFfm.java
+++ b/src/main/java/org/fusesource/jansi/ffm/AnsiConsoleSupportFfm.java
@@ -53,9 +53,11 @@ public class AnsiConsoleSupportFfm implements AnsiConsoleSupport {
 
             @Override
             public int getTerminalWidth(long console) {
-                CONSOLE_SCREEN_BUFFER_INFO info = new CONSOLE_SCREEN_BUFFER_INFO();
-                GetConsoleScreenBufferInfo(MemorySegment.ofAddress(console), info);
-                return info.windowWidth();
+                try (Arena session = Arena.ofConfined()) {
+                    CONSOLE_SCREEN_BUFFER_INFO info = new CONSOLE_SCREEN_BUFFER_INFO(session);
+                    GetConsoleScreenBufferInfo(MemorySegment.ofAddress(console), info);
+                    return info.windowWidth();
+                }
             }
 
             @Override

--- a/src/main/java/org/fusesource/jansi/ffm/AnsiConsoleSupportFfm.java
+++ b/src/main/java/org/fusesource/jansi/ffm/AnsiConsoleSupportFfm.java
@@ -41,11 +41,11 @@ public class AnsiConsoleSupportFfm implements AnsiConsoleSupport {
     @Override
     public CLibrary getCLibrary() {
         return new CLibrary() {
-            static final int TIOCGWINSZ;
-            static final GroupLayout wsLayout;
-            static final MethodHandle ioctl;
-            static final VarHandle ws_col;
-            static final MethodHandle isatty;
+            private static final int TIOCGWINSZ;
+            private static final GroupLayout wsLayout;
+            private static final MethodHandle ioctl;
+            private static final VarHandle ws_col;
+            private static final MethodHandle isatty;
 
             static {
                 String osName = System.getProperty("os.name");
@@ -148,10 +148,7 @@ public class AnsiConsoleSupportFfm implements AnsiConsoleSupport {
 
             @Override
             public String getErrorMessage(int errorCode) {
-                int bufferSize = 160;
-                MemorySegment data = Arena.ofAuto().allocate(bufferSize);
-                FormatMessageW(FORMAT_MESSAGE_FROM_SYSTEM, null, errorCode, 0, data, bufferSize, null);
-                return data.getUtf8String(0).trim();
+                return org.fusesource.jansi.ffm.Kernel32.getErrorMessage(errorCode);
             }
 
             @Override

--- a/src/main/java/org/fusesource/jansi/ffm/AnsiConsoleSupportFfm.java
+++ b/src/main/java/org/fusesource/jansi/ffm/AnsiConsoleSupportFfm.java
@@ -53,8 +53,8 @@ public class AnsiConsoleSupportFfm implements AnsiConsoleSupport {
 
             @Override
             public int getTerminalWidth(long console) {
-                try (Arena session = Arena.ofConfined()) {
-                    CONSOLE_SCREEN_BUFFER_INFO info = new CONSOLE_SCREEN_BUFFER_INFO(session);
+                try (Arena arena = Arena.ofConfined()) {
+                    CONSOLE_SCREEN_BUFFER_INFO info = new CONSOLE_SCREEN_BUFFER_INFO(arena);
                     GetConsoleScreenBufferInfo(MemorySegment.ofAddress(console), info);
                     return info.windowWidth();
                 }
@@ -68,8 +68,8 @@ public class AnsiConsoleSupportFfm implements AnsiConsoleSupport {
 
             @Override
             public int getConsoleMode(long console, int[] mode) {
-                try (Arena session = Arena.ofConfined()) {
-                    MemorySegment written = session.allocate(ValueLayout.JAVA_INT);
+                try (Arena arena = Arena.ofConfined()) {
+                    MemorySegment written = arena.allocate(ValueLayout.JAVA_INT);
                     int res = GetConsoleMode(MemorySegment.ofAddress(console), written);
                     mode[0] = written.getAtIndex(ValueLayout.JAVA_INT, 0);
                     return res;

--- a/src/main/java/org/fusesource/jansi/ffm/Kernel32.java
+++ b/src/main/java/org/fusesource/jansi/ffm/Kernel32.java
@@ -260,10 +260,10 @@ class Kernel32 {
         }
     }
 
-    public static int GetLastError(Object... x0) {
+    public static int GetLastError() {
         MethodHandle mh$ = requireNonNull(GetLastError$MH, "GetLastError");
         try {
-            return (int) mh$.invokeExact(x0);
+            return (int) mh$.invokeExact();
         } catch (Throwable ex$) {
             throw new AssertionError("should not reach here", ex$);
         }

--- a/src/main/java/org/fusesource/jansi/ffm/Kernel32.java
+++ b/src/main/java/org/fusesource/jansi/ffm/Kernel32.java
@@ -307,9 +307,11 @@ class Kernel32 {
 
     public static String getErrorMessage(int errorCode) {
         int bufferSize = 160;
-        MemorySegment data = Arena.ofAuto().allocate(bufferSize);
-        FormatMessageW(FORMAT_MESSAGE_FROM_SYSTEM, null, errorCode, 0, data, bufferSize, null);
-        return data.getUtf8String(0).trim();
+        try (Arena session = Arena.ofConfined()) {
+            MemorySegment data = session.allocate(bufferSize);
+            FormatMessageW(FORMAT_MESSAGE_FROM_SYSTEM, null, errorCode, 0, data, bufferSize, null);
+            return data.getUtf8String(0).trim();
+        }
     }
 
     private static final Linker LINKER = Linker.nativeLinker();

--- a/src/main/java/org/fusesource/jansi/ffm/Kernel32.java
+++ b/src/main/java/org/fusesource/jansi/ffm/Kernel32.java
@@ -27,12 +27,13 @@ import java.lang.foreign.SymbolLookup;
 import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.VarHandle;
+import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
 import static java.lang.foreign.ValueLayout.*;
 
 @SuppressWarnings("unused")
-final class Kernel32 {
+public final class Kernel32 {
 
     public static final int FORMAT_MESSAGE_FROM_SYSTEM = 0x00001000;
 
@@ -309,7 +310,7 @@ final class Kernel32 {
         try (Arena session = Arena.ofConfined()) {
             MemorySegment data = session.allocate(bufferSize);
             FormatMessageW(FORMAT_MESSAGE_FROM_SYSTEM, null, errorCode, 0, data, bufferSize, null);
-            return data.getUtf8String(0).trim();
+            return new String(data.toArray(JAVA_BYTE), StandardCharsets.UTF_16LE).trim();
         }
     }
 

--- a/src/main/java/org/fusesource/jansi/ffm/Kernel32.java
+++ b/src/main/java/org/fusesource/jansi/ffm/Kernel32.java
@@ -33,7 +33,7 @@ import java.util.Objects;
 import static java.lang.foreign.ValueLayout.*;
 
 @SuppressWarnings("unused")
-public final class Kernel32 {
+final class Kernel32 {
 
     public static final int FORMAT_MESSAGE_FROM_SYSTEM = 0x00001000;
 
@@ -330,18 +330,18 @@ public final class Kernel32 {
                 .orElse(null);
     }
 
-    static final OfBoolean C_BOOL$LAYOUT = ValueLayout.JAVA_BOOLEAN;
-    static final OfByte C_CHAR$LAYOUT = ValueLayout.JAVA_BYTE;
-    static final OfChar C_WCHAR$LAYOUT = ValueLayout.JAVA_CHAR;
-    static final OfShort C_SHORT$LAYOUT = ValueLayout.JAVA_SHORT;
-    static final OfShort C_WORD$LAYOUT = ValueLayout.JAVA_SHORT;
-    static final OfInt C_DWORD$LAYOUT = ValueLayout.JAVA_INT;
+    static final OfBoolean C_BOOL$LAYOUT = JAVA_BOOLEAN;
+    static final OfByte C_CHAR$LAYOUT = JAVA_BYTE;
+    static final OfChar C_WCHAR$LAYOUT = JAVA_CHAR;
+    static final OfShort C_SHORT$LAYOUT = JAVA_SHORT;
+    static final OfShort C_WORD$LAYOUT = JAVA_SHORT;
+    static final OfInt C_DWORD$LAYOUT = JAVA_INT;
     static final OfInt C_INT$LAYOUT = JAVA_INT;
-    static final OfLong C_LONG$LAYOUT = ValueLayout.JAVA_LONG;
-    static final OfLong C_LONG_LONG$LAYOUT = ValueLayout.JAVA_LONG;
-    static final OfFloat C_FLOAT$LAYOUT = ValueLayout.JAVA_FLOAT;
-    static final OfDouble C_DOUBLE$LAYOUT = ValueLayout.JAVA_DOUBLE;
-    static final AddressLayout C_POINTER$LAYOUT = ValueLayout.ADDRESS;
+    static final OfLong C_LONG$LAYOUT = JAVA_LONG;
+    static final OfLong C_LONG_LONG$LAYOUT = JAVA_LONG;
+    static final OfFloat C_FLOAT$LAYOUT = JAVA_FLOAT;
+    static final OfDouble C_DOUBLE$LAYOUT = JAVA_DOUBLE;
+    static final AddressLayout C_POINTER$LAYOUT = ADDRESS;
 
     static final MethodHandle WaitForSingleObject$MH =
             downcallHandle("WaitForSingleObject", FunctionDescriptor.of(C_INT$LAYOUT, C_POINTER$LAYOUT, C_INT$LAYOUT));

--- a/src/main/java/org/fusesource/jansi/ffm/Kernel32.java
+++ b/src/main/java/org/fusesource/jansi/ffm/Kernel32.java
@@ -105,7 +105,7 @@ class Kernel32 {
     public static MemorySegment GetStdHandle(int nStdHandle) {
         MethodHandle mh$ = requireNonNull(GetStdHandle$MH, "GetStdHandle");
         try {
-            return MemorySegment.ofAddress((long) mh$.invokeExact(nStdHandle));
+            return (MemorySegment) mh$.invokeExact(nStdHandle);
         } catch (Throwable ex$) {
             throw new AssertionError("should not reach here", ex$);
         }
@@ -121,14 +121,7 @@ class Kernel32 {
             MemorySegment Arguments) {
         MethodHandle mh$ = requireNonNull(FormatMessageW$MH, "FormatMessageW");
         try {
-            return (int) mh$.invokeExact(
-                    dwFlags,
-                    lpSource.address(),
-                    dwMessageId,
-                    dwLanguageId,
-                    lpBuffer.address(),
-                    nSize,
-                    Arguments.address());
+            return (int) mh$.invokeExact(dwFlags, lpSource, dwMessageId, dwLanguageId, lpBuffer, nSize, Arguments);
         } catch (Throwable ex$) {
             throw new AssertionError("should not reach here", ex$);
         }
@@ -155,7 +148,7 @@ class Kernel32 {
     public static int GetConsoleMode(MemorySegment hConsoleHandle, MemorySegment lpMode) {
         MethodHandle mh$ = requireNonNull(GetConsoleMode$MH, "GetConsoleMode");
         try {
-            return (int) mh$.invokeExact(hConsoleHandle.address(), lpMode.address());
+            return (int) mh$.invokeExact(hConsoleHandle, lpMode);
         } catch (Throwable ex$) {
             throw new AssertionError("should not reach here", ex$);
         }
@@ -164,7 +157,7 @@ class Kernel32 {
     public static int SetConsoleTitleW(MemorySegment lpConsoleTitle) {
         MethodHandle mh$ = requireNonNull(SetConsoleTitleW$MH, "SetConsoleTitleW");
         try {
-            return (int) mh$.invokeExact(lpConsoleTitle.address());
+            return (int) mh$.invokeExact(lpConsoleTitle);
         } catch (Throwable ex$) {
             throw new AssertionError("should not reach here", ex$);
         }
@@ -187,8 +180,7 @@ class Kernel32 {
             MemorySegment lpNumberOfCharsWritten) {
         MethodHandle mh$ = requireNonNull(FillConsoleOutputCharacterW$MH, "FillConsoleOutputCharacterW");
         try {
-            return (int) mh$.invokeExact(
-                    hConsoleOutput.address(), cCharacter, nLength, dwWriteCoord.seg, lpNumberOfCharsWritten.address());
+            return (int) mh$.invokeExact(hConsoleOutput, cCharacter, nLength, dwWriteCoord.seg, lpNumberOfCharsWritten);
         } catch (Throwable ex$) {
             throw new AssertionError("should not reach here", ex$);
         }
@@ -202,8 +194,7 @@ class Kernel32 {
             MemorySegment lpNumberOfAttrsWritten) {
         MethodHandle mh$ = requireNonNull(FillConsoleOutputAttribute$MH, "FillConsoleOutputAttribute");
         try {
-            return (int) mh$.invokeExact(
-                    hConsoleOutput, wAttribute, nLength, dwWriteCoord.seg, lpNumberOfAttrsWritten.address());
+            return (int) mh$.invokeExact(hConsoleOutput, wAttribute, nLength, dwWriteCoord.seg, lpNumberOfAttrsWritten);
         } catch (Throwable ex$) {
             throw new AssertionError("should not reach here", ex$);
         }
@@ -228,8 +219,7 @@ class Kernel32 {
             MemorySegment hConsoleInput, MemorySegment lpBuffer, int nLength, MemorySegment lpNumberOfEventsRead) {
         MethodHandle mh$ = requireNonNull(ReadConsoleInputW$MH, "ReadConsoleInputW");
         try {
-            return (int) mh$.invokeExact(
-                    hConsoleInput.address(), lpBuffer.address(), nLength, lpNumberOfEventsRead.address());
+            return (int) mh$.invokeExact(hConsoleInput, lpBuffer, nLength, lpNumberOfEventsRead);
         } catch (Throwable ex$) {
             throw new AssertionError("should not reach here", ex$);
         }
@@ -239,8 +229,7 @@ class Kernel32 {
             MemorySegment hConsoleInput, MemorySegment lpBuffer, int nLength, MemorySegment lpNumberOfEventsRead) {
         MethodHandle mh$ = requireNonNull(PeekConsoleInputW$MH, "PeekConsoleInputW");
         try {
-            return (int) mh$.invokeExact(
-                    hConsoleInput.address(), lpBuffer.address(), nLength, lpNumberOfEventsRead.address());
+            return (int) mh$.invokeExact(hConsoleInput, lpBuffer, nLength, lpNumberOfEventsRead);
         } catch (Throwable ex$) {
             throw new AssertionError("should not reach here", ex$);
         }
@@ -250,7 +239,7 @@ class Kernel32 {
             MemorySegment hConsoleOutput, CONSOLE_SCREEN_BUFFER_INFO lpConsoleScreenBufferInfo) {
         MethodHandle mh$ = requireNonNull(GetConsoleScreenBufferInfo$MH, "GetConsoleScreenBufferInfo");
         try {
-            return (int) mh$.invokeExact(hConsoleOutput.address(), lpConsoleScreenBufferInfo.seg);
+            return (int) mh$.invokeExact(hConsoleOutput, lpConsoleScreenBufferInfo.seg);
         } catch (Throwable ex$) {
             throw new AssertionError("should not reach here", ex$);
         }

--- a/src/main/java/org/fusesource/jansi/ffm/Kernel32.java
+++ b/src/main/java/org/fusesource/jansi/ffm/Kernel32.java
@@ -282,9 +282,9 @@ final class Kernel32 {
 
     public static INPUT_RECORD[] readConsoleInputHelper(MemorySegment handle, int count, boolean peek)
             throws IOException {
-        try (Arena session = Arena.ofConfined()) {
-            MemorySegment inputRecordPtr = session.allocateArray(INPUT_RECORD.LAYOUT, count);
-            MemorySegment length = session.allocate(JAVA_INT, 0);
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment inputRecordPtr = arena.allocateArray(INPUT_RECORD.LAYOUT, count);
+            MemorySegment length = arena.allocate(JAVA_INT, 0);
             int res = peek
                     ? PeekConsoleInputW(handle, inputRecordPtr, count, length)
                     : ReadConsoleInputW(handle, inputRecordPtr, count, length);
@@ -307,8 +307,8 @@ final class Kernel32 {
 
     public static String getErrorMessage(int errorCode) {
         int bufferSize = 160;
-        try (Arena session = Arena.ofConfined()) {
-            MemorySegment data = session.allocate(bufferSize);
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment data = arena.allocate(bufferSize);
             FormatMessageW(FORMAT_MESSAGE_FROM_SYSTEM, null, errorCode, 0, data, bufferSize, null);
             return new String(data.toArray(JAVA_BYTE), StandardCharsets.UTF_16LE).trim();
         }
@@ -627,12 +627,12 @@ final class Kernel32 {
 
         final MemorySegment seg;
 
-        public CHAR_INFO(Arena session) {
-            this(session.allocate(LAYOUT));
+        public CHAR_INFO(Arena arena) {
+            this(arena.allocate(LAYOUT));
         }
 
-        public CHAR_INFO(Arena session, char c, short a) {
-            this(session);
+        public CHAR_INFO(Arena arena, char c, short a) {
+            this(arena);
             UnicodeChar$VH.set(seg, c);
             Attributes$VH.set(seg, a);
         }
@@ -660,8 +660,8 @@ final class Kernel32 {
 
         private final MemorySegment seg;
 
-        public CONSOLE_SCREEN_BUFFER_INFO(Arena session) {
-            this(session.allocate(LAYOUT));
+        public CONSOLE_SCREEN_BUFFER_INFO(Arena arena) {
+            this(arena.allocate(LAYOUT));
         }
 
         CONSOLE_SCREEN_BUFFER_INFO(MemorySegment seg) {
@@ -706,12 +706,12 @@ final class Kernel32 {
 
         private final MemorySegment seg;
 
-        public COORD(Arena session) {
-            this(session.allocate(LAYOUT));
+        public COORD(Arena arena) {
+            this(arena.allocate(LAYOUT));
         }
 
-        public COORD(Arena session, short x, short y) {
-            this(session.allocate(LAYOUT));
+        public COORD(Arena arena, short x, short y) {
+            this(arena.allocate(LAYOUT));
             x(x);
             y(y);
         }
@@ -740,8 +740,8 @@ final class Kernel32 {
             COORD.y$VH.set(seg, y);
         }
 
-        public COORD copy(Arena session) {
-            return new COORD(session.allocate(LAYOUT).copyFrom(seg));
+        public COORD copy(Arena arena) {
+            return new COORD(arena.allocate(LAYOUT).copyFrom(seg));
         }
     }
 
@@ -799,8 +799,8 @@ final class Kernel32 {
             Top$VH.set(seg, t);
         }
 
-        public SMALL_RECT copy(Arena session) {
-            return new SMALL_RECT(session.allocate(LAYOUT).copyFrom(seg));
+        public SMALL_RECT copy(Arena arena) {
+            return new SMALL_RECT(arena.allocate(LAYOUT).copyFrom(seg));
         }
     }
 

--- a/src/main/java/org/fusesource/jansi/ffm/Kernel32.java
+++ b/src/main/java/org/fusesource/jansi/ffm/Kernel32.java
@@ -410,7 +410,7 @@ final class Kernel32 {
     static final MethodHandle _get_osfhandle$MH =
             downcallHandle("_get_osfhandle", FunctionDescriptor.of(C_POINTER$LAYOUT, C_INT$LAYOUT));
 
-    public static class INPUT_RECORD {
+    public static final class INPUT_RECORD {
         static final MemoryLayout LAYOUT = MemoryLayout.structLayout(
                 ValueLayout.JAVA_SHORT.withName("EventType"),
                 MemoryLayout.unionLayout(
@@ -446,7 +446,7 @@ final class Kernel32 {
         }
     }
 
-    public static class MENU_EVENT_RECORD {
+    public static final class MENU_EVENT_RECORD {
 
         static final GroupLayout LAYOUT = MemoryLayout.structLayout(C_DWORD$LAYOUT.withName("dwCommandId"));
         static final VarHandle COMMAND_ID = varHandle(LAYOUT, "dwCommandId");
@@ -466,7 +466,7 @@ final class Kernel32 {
         }
     }
 
-    public static class FOCUS_EVENT_RECORD {
+    public static final class FOCUS_EVENT_RECORD {
 
         static final GroupLayout LAYOUT = MemoryLayout.structLayout(C_BOOL$LAYOUT.withName("bSetFocus"));
         static final VarHandle SET_FOCUS = varHandle(LAYOUT, "bSetFocus");
@@ -490,7 +490,7 @@ final class Kernel32 {
         }
     }
 
-    public static class WINDOW_BUFFER_SIZE_RECORD {
+    public static final class WINDOW_BUFFER_SIZE_RECORD {
 
         static final GroupLayout LAYOUT = MemoryLayout.structLayout(COORD.LAYOUT.withName("size"));
         static final long SIZE_OFFSET = byteOffset(LAYOUT, "size");
@@ -510,7 +510,7 @@ final class Kernel32 {
         }
     }
 
-    public static class MOUSE_EVENT_RECORD {
+    public static final class MOUSE_EVENT_RECORD {
 
         private static final MemoryLayout LAYOUT = MemoryLayout.structLayout(
                 COORD.LAYOUT.withName("dwMousePosition"),
@@ -554,7 +554,7 @@ final class Kernel32 {
         }
     }
 
-    public static class KEY_EVENT_RECORD {
+    public static final class KEY_EVENT_RECORD {
 
         static final MemoryLayout LAYOUT = MemoryLayout.structLayout(
                 JAVA_INT.withName("bKeyDown"),
@@ -616,7 +616,7 @@ final class Kernel32 {
         }
     }
 
-    public static class CHAR_INFO {
+    public static final class CHAR_INFO {
 
         static final GroupLayout LAYOUT = MemoryLayout.structLayout(
                 MemoryLayout.unionLayout(C_WCHAR$LAYOUT.withName("UnicodeChar"), C_CHAR$LAYOUT.withName("AsciiChar"))
@@ -646,7 +646,7 @@ final class Kernel32 {
         }
     }
 
-    public static class CONSOLE_SCREEN_BUFFER_INFO {
+    public static final class CONSOLE_SCREEN_BUFFER_INFO {
         static final GroupLayout LAYOUT = MemoryLayout.structLayout(
                 COORD.LAYOUT.withName("dwSize"),
                 COORD.LAYOUT.withName("dwCursorPosition"),
@@ -697,7 +697,7 @@ final class Kernel32 {
         }
     }
 
-    public static class COORD {
+    public static final class COORD {
 
         static final GroupLayout LAYOUT =
                 MemoryLayout.structLayout(C_SHORT$LAYOUT.withName("x"), C_SHORT$LAYOUT.withName("y"));
@@ -745,7 +745,7 @@ final class Kernel32 {
         }
     }
 
-    public static class SMALL_RECT {
+    public static final class SMALL_RECT {
 
         static final GroupLayout LAYOUT = MemoryLayout.structLayout(
                 C_SHORT$LAYOUT.withName("Left"),

--- a/src/main/java/org/fusesource/jansi/ffm/Kernel32.java
+++ b/src/main/java/org/fusesource/jansi/ffm/Kernel32.java
@@ -333,16 +333,16 @@ class Kernel32 {
 
     static final OfBoolean C_BOOL$LAYOUT = ValueLayout.JAVA_BOOLEAN;
     static final OfByte C_CHAR$LAYOUT = ValueLayout.JAVA_BYTE;
-    static final OfChar C_WCHAR$LAYOUT = ValueLayout.JAVA_CHAR.withByteAlignment(16);
-    static final OfShort C_SHORT$LAYOUT = ValueLayout.JAVA_SHORT.withByteAlignment(16);
-    static final OfShort C_WORD$LAYOUT = ValueLayout.JAVA_SHORT.withByteAlignment(16);
-    static final OfInt C_DWORD$LAYOUT = ValueLayout.JAVA_INT.withByteAlignment(32);
-    static final OfInt C_INT$LAYOUT = JAVA_INT.withByteAlignment(32);
-    static final OfLong C_LONG$LAYOUT = ValueLayout.JAVA_LONG.withByteAlignment(64);
-    static final OfLong C_LONG_LONG$LAYOUT = ValueLayout.JAVA_LONG.withByteAlignment(64);
-    static final OfFloat C_FLOAT$LAYOUT = ValueLayout.JAVA_FLOAT.withByteAlignment(32);
-    static final OfDouble C_DOUBLE$LAYOUT = ValueLayout.JAVA_DOUBLE.withByteAlignment(64);
-    static final AddressLayout C_POINTER$LAYOUT = ValueLayout.ADDRESS.withByteAlignment(64);
+    static final OfChar C_WCHAR$LAYOUT = ValueLayout.JAVA_CHAR;
+    static final OfShort C_SHORT$LAYOUT = ValueLayout.JAVA_SHORT;
+    static final OfShort C_WORD$LAYOUT = ValueLayout.JAVA_SHORT;
+    static final OfInt C_DWORD$LAYOUT = ValueLayout.JAVA_INT;
+    static final OfInt C_INT$LAYOUT = JAVA_INT;
+    static final OfLong C_LONG$LAYOUT = ValueLayout.JAVA_LONG;
+    static final OfLong C_LONG_LONG$LAYOUT = ValueLayout.JAVA_LONG;
+    static final OfFloat C_FLOAT$LAYOUT = ValueLayout.JAVA_FLOAT;
+    static final OfDouble C_DOUBLE$LAYOUT = ValueLayout.JAVA_DOUBLE;
+    static final AddressLayout C_POINTER$LAYOUT = ValueLayout.ADDRESS;
 
     //    static final MethodHandle WaitForSingleObject$MH =
     //            downcallHandle("WaitForSingleObject", FunctionDescriptor.of(C_INT$LAYOUT, C_POINTER$LAYOUT,

--- a/src/main/java/org/fusesource/jansi/ffm/Kernel32.java
+++ b/src/main/java/org/fusesource/jansi/ffm/Kernel32.java
@@ -333,8 +333,7 @@ class Kernel32 {
     static final AddressLayout C_POINTER$LAYOUT = ValueLayout.ADDRESS;
 
     static final MethodHandle WaitForSingleObject$MH =
-            downcallHandle("WaitForSingleObject", FunctionDescriptor.of(C_INT$LAYOUT, C_POINTER$LAYOUT,
-                    C_INT$LAYOUT));
+            downcallHandle("WaitForSingleObject", FunctionDescriptor.of(C_INT$LAYOUT, C_POINTER$LAYOUT, C_INT$LAYOUT));
     static final MethodHandle GetStdHandle$MH =
             downcallHandle("GetStdHandle", FunctionDescriptor.of(C_POINTER$LAYOUT, C_INT$LAYOUT));
     static final MethodHandle FormatMessageW$MH = downcallHandle(

--- a/src/main/java/org/fusesource/jansi/ffm/Kernel32.java
+++ b/src/main/java/org/fusesource/jansi/ffm/Kernel32.java
@@ -319,6 +319,7 @@ class Kernel32 {
     private static final SymbolLookup SYMBOL_LOOKUP;
 
     static {
+        System.loadLibrary("Kernel32");
         SymbolLookup loaderLookup = SymbolLookup.loaderLookup();
         SYMBOL_LOOKUP =
                 name -> loaderLookup.find(name).or(() -> LINKER.defaultLookup().find(name));

--- a/src/main/java/org/fusesource/jansi/ffm/Kernel32.java
+++ b/src/main/java/org/fusesource/jansi/ffm/Kernel32.java
@@ -425,10 +425,6 @@ final class Kernel32 {
 
         private final MemorySegment seg;
 
-        public INPUT_RECORD() {
-            this(Arena.ofAuto().allocate(LAYOUT));
-        }
-
         INPUT_RECORD(MemorySegment seg) {
             this.seg = seg;
         }
@@ -457,10 +453,6 @@ final class Kernel32 {
 
         private final MemorySegment seg;
 
-        public MENU_EVENT_RECORD() {
-            this(Arena.ofAuto().allocate(LAYOUT));
-        }
-
         MENU_EVENT_RECORD(MemorySegment seg) {
             this.seg = seg;
         }
@@ -480,10 +472,6 @@ final class Kernel32 {
         static final VarHandle SET_FOCUS = varHandle(LAYOUT, "bSetFocus");
 
         private final MemorySegment seg;
-
-        public FOCUS_EVENT_RECORD() {
-            this(Arena.ofAuto().allocate(LAYOUT));
-        }
 
         FOCUS_EVENT_RECORD(MemorySegment seg) {
             this.seg = Objects.requireNonNull(seg);
@@ -508,10 +496,6 @@ final class Kernel32 {
         static final long SIZE_OFFSET = byteOffset(LAYOUT, "size");
 
         private final MemorySegment seg;
-
-        public WINDOW_BUFFER_SIZE_RECORD() {
-            this(Arena.ofAuto().allocate(LAYOUT));
-        }
 
         WINDOW_BUFFER_SIZE_RECORD(MemorySegment seg) {
             this.seg = seg;
@@ -539,10 +523,6 @@ final class Kernel32 {
         private static final VarHandle EVENT_FLAGS = varHandle(LAYOUT, "dwEventFlags");
 
         private final MemorySegment seg;
-
-        public MOUSE_EVENT_RECORD() {
-            this(Arena.ofAuto().allocate(LAYOUT));
-        }
 
         MOUSE_EVENT_RECORD(MemorySegment seg) {
             this.seg = Objects.requireNonNull(seg);
@@ -596,10 +576,6 @@ final class Kernel32 {
 
         final MemorySegment seg;
 
-        public KEY_EVENT_RECORD() {
-            this(Arena.ofAuto().allocate(LAYOUT));
-        }
-
         KEY_EVENT_RECORD(MemorySegment seg) {
             this.seg = seg;
         }
@@ -651,12 +627,12 @@ final class Kernel32 {
 
         final MemorySegment seg;
 
-        public CHAR_INFO() {
-            this(Arena.ofAuto().allocate(LAYOUT));
+        public CHAR_INFO(Arena session) {
+            this(session.allocate(LAYOUT));
         }
 
-        public CHAR_INFO(char c, short a) {
-            this();
+        public CHAR_INFO(Arena session, char c, short a) {
+            this(session);
             UnicodeChar$VH.set(seg, c);
             Attributes$VH.set(seg, a);
         }
@@ -684,8 +660,8 @@ final class Kernel32 {
 
         private final MemorySegment seg;
 
-        public CONSOLE_SCREEN_BUFFER_INFO() {
-            this(Arena.ofAuto().allocate(LAYOUT));
+        public CONSOLE_SCREEN_BUFFER_INFO(Arena session) {
+            this(session.allocate(LAYOUT));
         }
 
         CONSOLE_SCREEN_BUFFER_INFO(MemorySegment seg) {
@@ -730,18 +706,14 @@ final class Kernel32 {
 
         private final MemorySegment seg;
 
-        public COORD() {
-            this(Arena.ofAuto().allocate(LAYOUT));
+        public COORD(Arena session) {
+            this(session.allocate(LAYOUT));
         }
 
-        public COORD(short x, short y) {
-            this(Arena.ofAuto().allocate(LAYOUT));
+        public COORD(Arena session, short x, short y) {
+            this(session.allocate(LAYOUT));
             x(x);
             y(y);
-        }
-
-        public COORD(COORD from) {
-            this(Arena.ofAuto().allocate(LAYOUT).copyFrom(Objects.requireNonNull(from).seg));
         }
 
         COORD(MemorySegment seg) {
@@ -768,8 +740,8 @@ final class Kernel32 {
             COORD.y$VH.set(seg, y);
         }
 
-        public COORD copy() {
-            return new COORD(this);
+        public COORD copy(Arena session) {
+            return new COORD(session.allocate(LAYOUT).copyFrom(seg));
         }
     }
 
@@ -786,14 +758,6 @@ final class Kernel32 {
         static final VarHandle Bottom$VH = varHandle(LAYOUT, "Bottom");
 
         private final MemorySegment seg;
-
-        public SMALL_RECT() {
-            this(Arena.ofAuto().allocate(LAYOUT));
-        }
-
-        public SMALL_RECT(SMALL_RECT from) {
-            this(Arena.ofAuto().allocate(LAYOUT).copyFrom(from.seg));
-        }
 
         SMALL_RECT(MemorySegment seg, long offset) {
             this(seg.asSlice(offset, LAYOUT.byteSize()));
@@ -835,8 +799,8 @@ final class Kernel32 {
             Top$VH.set(seg, t);
         }
 
-        public SMALL_RECT copy() {
-            return new SMALL_RECT(this);
+        public SMALL_RECT copy(Arena session) {
+            return new SMALL_RECT(session.allocate(LAYOUT).copyFrom(seg));
         }
     }
 

--- a/src/main/java/org/fusesource/jansi/ffm/Kernel32.java
+++ b/src/main/java/org/fusesource/jansi/ffm/Kernel32.java
@@ -39,7 +39,7 @@ import static java.lang.foreign.ValueLayout.OfInt;
 import static java.lang.foreign.ValueLayout.OfLong;
 import static java.lang.foreign.ValueLayout.OfShort;
 
-@SuppressWarnings({"unused", "CopyConstructorMissesField"})
+@SuppressWarnings("unused")
 class Kernel32 {
 
     public static final int FORMAT_MESSAGE_FROM_SYSTEM = 0x00001000;
@@ -93,14 +93,14 @@ class Kernel32 {
     public static final short MENU_EVENT = 0x0008;
     public static final short FOCUS_EVENT = 0x0010;
 
-    //    public static int WaitForSingleObject(MemorySegment hHandle, int dwMilliseconds) {
-    //        MethodHandle mh$ = requireNonNull(WaitForSingleObject$MH, "WaitForSingleObject");
-    //        try {
-    //            return (int) mh$.invokeExact(hHandle, dwMilliseconds);
-    //        } catch (Throwable ex$) {
-    //            throw new AssertionError("should not reach here", ex$);
-    //        }
-    //    }
+    public static int WaitForSingleObject(MemorySegment hHandle, int dwMilliseconds) {
+        MethodHandle mh$ = requireNonNull(WaitForSingleObject$MH, "WaitForSingleObject");
+        try {
+            return (int) mh$.invokeExact(hHandle, dwMilliseconds);
+        } catch (Throwable ex$) {
+            throw new AssertionError("should not reach here", ex$);
+        }
+    }
 
     public static MemorySegment GetStdHandle(int nStdHandle) {
         MethodHandle mh$ = requireNonNull(GetStdHandle$MH, "GetStdHandle");
@@ -309,9 +309,7 @@ class Kernel32 {
 
     static {
         System.loadLibrary("Kernel32");
-        SymbolLookup loaderLookup = SymbolLookup.loaderLookup();
-        SYMBOL_LOOKUP =
-                name -> loaderLookup.find(name).or(() -> LINKER.defaultLookup().find(name));
+        SYMBOL_LOOKUP = SymbolLookup.loaderLookup().or(LINKER.defaultLookup());
     }
 
     static MethodHandle downcallHandle(String name, FunctionDescriptor fdesc) {
@@ -334,9 +332,9 @@ class Kernel32 {
     static final OfDouble C_DOUBLE$LAYOUT = ValueLayout.JAVA_DOUBLE;
     static final AddressLayout C_POINTER$LAYOUT = ValueLayout.ADDRESS;
 
-    //    static final MethodHandle WaitForSingleObject$MH =
-    //            downcallHandle("WaitForSingleObject", FunctionDescriptor.of(C_INT$LAYOUT, C_POINTER$LAYOUT,
-    // C_INT$LAYOUT));
+    static final MethodHandle WaitForSingleObject$MH =
+            downcallHandle("WaitForSingleObject", FunctionDescriptor.of(C_INT$LAYOUT, C_POINTER$LAYOUT,
+                    C_INT$LAYOUT));
     static final MethodHandle GetStdHandle$MH =
             downcallHandle("GetStdHandle", FunctionDescriptor.of(C_POINTER$LAYOUT, C_INT$LAYOUT));
     static final MethodHandle FormatMessageW$MH = downcallHandle(

--- a/src/main/java/org/fusesource/jansi/ffm/Kernel32.java
+++ b/src/main/java/org/fusesource/jansi/ffm/Kernel32.java
@@ -314,19 +314,17 @@ final class Kernel32 {
         }
     }
 
-    private static final Linker LINKER = Linker.nativeLinker();
-
     private static final SymbolLookup SYMBOL_LOOKUP;
 
     static {
         System.loadLibrary("Kernel32");
-        SYMBOL_LOOKUP = SymbolLookup.loaderLookup().or(LINKER.defaultLookup());
+        SYMBOL_LOOKUP = SymbolLookup.loaderLookup().or(Linker.nativeLinker().defaultLookup());
     }
 
     static MethodHandle downcallHandle(String name, FunctionDescriptor fdesc) {
         return SYMBOL_LOOKUP
                 .find(name)
-                .map(addr -> LINKER.downcallHandle(addr, fdesc))
+                .map(addr -> Linker.nativeLinker().downcallHandle(addr, fdesc))
                 .orElse(null);
     }
 

--- a/src/main/java/org/fusesource/jansi/ffm/Kernel32.java
+++ b/src/main/java/org/fusesource/jansi/ffm/Kernel32.java
@@ -29,18 +29,10 @@ import java.lang.invoke.MethodHandle;
 import java.lang.invoke.VarHandle;
 import java.util.Objects;
 
-import static java.lang.foreign.ValueLayout.JAVA_INT;
-import static java.lang.foreign.ValueLayout.OfBoolean;
-import static java.lang.foreign.ValueLayout.OfByte;
-import static java.lang.foreign.ValueLayout.OfChar;
-import static java.lang.foreign.ValueLayout.OfDouble;
-import static java.lang.foreign.ValueLayout.OfFloat;
-import static java.lang.foreign.ValueLayout.OfInt;
-import static java.lang.foreign.ValueLayout.OfLong;
-import static java.lang.foreign.ValueLayout.OfShort;
+import static java.lang.foreign.ValueLayout.*;
 
 @SuppressWarnings("unused")
-class Kernel32 {
+final class Kernel32 {
 
     public static final int FORMAT_MESSAGE_FROM_SYSTEM = 0x00001000;
 
@@ -269,6 +261,24 @@ class Kernel32 {
         }
     }
 
+    public static int GetFileType(MemorySegment hFile) {
+        MethodHandle mh$ = requireNonNull(GetFileType$MH, "GetFileType");
+        try {
+            return (int) mh$.invokeExact(hFile);
+        } catch (Throwable ex$) {
+            throw new AssertionError("should not reach here", ex$);
+        }
+    }
+
+    public static MemorySegment _get_osfhandle(int fd) {
+        MethodHandle mh$ = requireNonNull(_get_osfhandle$MH, "_get_osfhandle");
+        try {
+            return (MemorySegment) mh$.invokeExact(fd);
+        } catch (Throwable ex$) {
+            throw new AssertionError("should not reach here", ex$);
+        }
+    }
+
     public static INPUT_RECORD[] readConsoleInputHelper(MemorySegment handle, int count, boolean peek)
             throws IOException {
         try (Arena session = Arena.ofConfined()) {
@@ -396,6 +406,10 @@ class Kernel32 {
                     COORD.LAYOUT,
                     C_POINTER$LAYOUT));
     static final MethodHandle GetLastError$MH = downcallHandle("GetLastError", FunctionDescriptor.of(C_INT$LAYOUT));
+    static final MethodHandle GetFileType$MH =
+            downcallHandle("GetFileType", FunctionDescriptor.of(C_INT$LAYOUT, C_POINTER$LAYOUT));
+    static final MethodHandle _get_osfhandle$MH =
+            downcallHandle("_get_osfhandle", FunctionDescriptor.of(C_POINTER$LAYOUT, C_INT$LAYOUT));
 
     public static class INPUT_RECORD {
         static final MemoryLayout LAYOUT = MemoryLayout.structLayout(

--- a/src/main/java/org/fusesource/jansi/ffm/Kernel32.java
+++ b/src/main/java/org/fusesource/jansi/ffm/Kernel32.java
@@ -139,7 +139,7 @@ class Kernel32 {
     public static int SetConsoleMode(MemorySegment hConsoleHandle, int dwMode) {
         MethodHandle mh$ = requireNonNull(SetConsoleMode$MH, "SetConsoleMode");
         try {
-            return (int) mh$.invokeExact(hConsoleHandle.address(), dwMode);
+            return (int) mh$.invokeExact(hConsoleHandle, dwMode);
         } catch (Throwable ex$) {
             throw new AssertionError("should not reach here", ex$);
         }

--- a/src/main/java/org/fusesource/jansi/ffm/PosixCLibrary.java
+++ b/src/main/java/org/fusesource/jansi/ffm/PosixCLibrary.java
@@ -15,11 +15,11 @@
  */
 package org.fusesource.jansi.ffm;
 
-import org.fusesource.jansi.AnsiConsoleSupport;
-
 import java.lang.foreign.*;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.VarHandle;
+
+import org.fusesource.jansi.AnsiConsoleSupport;
 
 final class PosixCLibrary implements AnsiConsoleSupport.CLibrary {
     private static final int TIOCGWINSZ;

--- a/src/main/java/org/fusesource/jansi/ffm/PosixCLibrary.java
+++ b/src/main/java/org/fusesource/jansi/ffm/PosixCLibrary.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2009-2023 the original author(s).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fusesource.jansi.ffm;
+
+import org.fusesource.jansi.AnsiConsoleSupport;
+
+import java.lang.foreign.*;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.VarHandle;
+
+final class PosixCLibrary implements AnsiConsoleSupport.CLibrary {
+    private static final int TIOCGWINSZ;
+    private static final GroupLayout wsLayout;
+    private static final MethodHandle ioctl;
+    private static final VarHandle ws_col;
+    private static final MethodHandle isatty;
+
+    static {
+        String osName = System.getProperty("os.name");
+        if (osName.startsWith("Linux")) {
+            String arch = System.getProperty("os.arch");
+            boolean isMipsPpcOrSparc =
+                    arch.startsWith("mips") || arch.startsWith("ppc") || arch.startsWith("sparc");
+            TIOCGWINSZ = isMipsPpcOrSparc ? 0x40087468 : 0x00005413;
+        } else if (osName.startsWith("Solaris") || osName.startsWith("SunOS")) {
+            int _TIOC = ('T' << 8);
+            TIOCGWINSZ = (_TIOC | 104);
+        } else if (osName.startsWith("Mac") || osName.startsWith("Darwin")) {
+            TIOCGWINSZ = 0x40087468;
+        } else if (osName.startsWith("FreeBSD")) {
+            TIOCGWINSZ = 0x40087468;
+        } else {
+            throw new UnsupportedOperationException();
+        }
+
+        wsLayout = MemoryLayout.structLayout(
+                ValueLayout.JAVA_SHORT.withName("ws_row"),
+                ValueLayout.JAVA_SHORT.withName("ws_col"),
+                ValueLayout.JAVA_SHORT,
+                ValueLayout.JAVA_SHORT);
+        ws_col = wsLayout.varHandle(MemoryLayout.PathElement.groupElement("ws_col"));
+        Linker linker = Linker.nativeLinker();
+        ioctl = linker.downcallHandle(
+                linker.defaultLookup().find("ioctl").get(),
+                FunctionDescriptor.of(
+                        ValueLayout.JAVA_INT, ValueLayout.JAVA_INT, ValueLayout.JAVA_LONG, ValueLayout.ADDRESS),
+                Linker.Option.firstVariadicArg(2));
+        isatty = linker.downcallHandle(
+                linker.defaultLookup().find("isatty").get(),
+                FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.JAVA_INT));
+    }
+
+    @Override
+    public short getTerminalWidth(int fd) {
+        try (Arena session = Arena.ofConfined()) {
+            MemorySegment segment = session.allocate(wsLayout);
+            int res = (int) ioctl.invoke(fd, (long) TIOCGWINSZ, segment);
+            return (short) ws_col.get(segment);
+        } catch (Throwable e) {
+            throw new RuntimeException("Unable to ioctl(TIOCGWINSZ)", e);
+        }
+    }
+
+    @Override
+    public int isTty(int fd) {
+        try {
+            return (int) isatty.invoke(fd);
+        } catch (Throwable e) {
+            throw new RuntimeException("Unable to call isatty", e);
+        }
+    }
+}

--- a/src/main/java/org/fusesource/jansi/ffm/PosixCLibrary.java
+++ b/src/main/java/org/fusesource/jansi/ffm/PosixCLibrary.java
@@ -32,8 +32,7 @@ final class PosixCLibrary implements AnsiConsoleSupport.CLibrary {
         String osName = System.getProperty("os.name");
         if (osName.startsWith("Linux")) {
             String arch = System.getProperty("os.arch");
-            boolean isMipsPpcOrSparc =
-                    arch.startsWith("mips") || arch.startsWith("ppc") || arch.startsWith("sparc");
+            boolean isMipsPpcOrSparc = arch.startsWith("mips") || arch.startsWith("ppc") || arch.startsWith("sparc");
             TIOCGWINSZ = isMipsPpcOrSparc ? 0x40087468 : 0x00005413;
         } else if (osName.startsWith("Solaris") || osName.startsWith("SunOS")) {
             int _TIOC = ('T' << 8);

--- a/src/main/java/org/fusesource/jansi/ffm/PosixCLibrary.java
+++ b/src/main/java/org/fusesource/jansi/ffm/PosixCLibrary.java
@@ -64,8 +64,8 @@ final class PosixCLibrary implements AnsiConsoleSupport.CLibrary {
 
     @Override
     public short getTerminalWidth(int fd) {
-        try (Arena session = Arena.ofConfined()) {
-            MemorySegment segment = session.allocate(wsLayout);
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment segment = arena.allocate(wsLayout);
             int res = (int) ioctl.invoke(fd, (long) TIOCGWINSZ, segment);
             return (short) ws_col.get(segment);
         } catch (Throwable e) {

--- a/src/main/java/org/fusesource/jansi/ffm/WindowsAnsiProcessor.java
+++ b/src/main/java/org/fusesource/jansi/ffm/WindowsAnsiProcessor.java
@@ -20,6 +20,7 @@ import java.io.OutputStream;
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
+import java.nio.charset.StandardCharsets;
 
 import org.fusesource.jansi.WindowsSupport;
 import org.fusesource.jansi.io.AnsiProcessor;
@@ -432,7 +433,9 @@ public class WindowsAnsiProcessor extends AnsiProcessor {
     @Override
     protected void processChangeWindowTitle(String title) {
         try (Arena session = Arena.ofConfined()) {
-            MemorySegment str = session.allocateUtf8String(title);
+            byte[] bytes = title.getBytes(StandardCharsets.UTF_16LE);
+            MemorySegment str = session.allocate(bytes.length + 2);
+            MemorySegment.copy(bytes, 0, str, ValueLayout.JAVA_BYTE, 0, bytes.length);
             SetConsoleTitleW(str);
         }
     }

--- a/src/main/java/org/fusesource/jansi/ffm/WindowsAnsiProcessor.java
+++ b/src/main/java/org/fusesource/jansi/ffm/WindowsAnsiProcessor.java
@@ -131,10 +131,8 @@ public class WindowsAnsiProcessor extends AnsiProcessor {
     }
 
     private void applyCursorPosition() throws IOException {
-        try (Arena arena = Arena.ofConfined()) {
-            if (SetConsoleCursorPosition(console, info.cursorPosition().copy(arena)) == 0) {
-                throw new IOException(WindowsSupport.getLastErrorMessage());
-            }
+        if (SetConsoleCursorPosition(console, info.cursorPosition()) == 0) {
+            throw new IOException(WindowsSupport.getLastErrorMessage());
         }
     }
 
@@ -172,10 +170,10 @@ public class WindowsAnsiProcessor extends AnsiProcessor {
                             console,
                             info.attributes(),
                             lengthToEnd,
-                            info.cursorPosition().copy(arena),
+                            info.cursorPosition(),
                             written);
                     FillConsoleOutputCharacterW(
-                            console, ' ', lengthToEnd, info.cursorPosition().copy(arena), written);
+                            console, ' ', lengthToEnd, info.cursorPosition(), written);
                     break;
                 default:
                     break;
@@ -211,10 +209,10 @@ public class WindowsAnsiProcessor extends AnsiProcessor {
                             console,
                             info.attributes(),
                             lengthToLastCol,
-                            info.cursorPosition().copy(arena),
+                            info.cursorPosition(),
                             written);
                     FillConsoleOutputCharacterW(
-                            console, ' ', lengthToLastCol, info.cursorPosition().copy(arena), written);
+                            console, ' ', lengthToLastCol, info.cursorPosition(), written);
                     break;
                 default:
                     break;

--- a/src/main/java/org/fusesource/jansi/ffm/WindowsAnsiProcessor.java
+++ b/src/main/java/org/fusesource/jansi/ffm/WindowsAnsiProcessor.java
@@ -166,14 +166,8 @@ public class WindowsAnsiProcessor extends AnsiProcessor {
                             (info.window().bottom() - info.cursorPosition().y())
                                             * info.size().x()
                                     + (info.size().x() - info.cursorPosition().x());
-                    FillConsoleOutputAttribute(
-                            console,
-                            info.attributes(),
-                            lengthToEnd,
-                            info.cursorPosition(),
-                            written);
-                    FillConsoleOutputCharacterW(
-                            console, ' ', lengthToEnd, info.cursorPosition(), written);
+                    FillConsoleOutputAttribute(console, info.attributes(), lengthToEnd, info.cursorPosition(), written);
+                    FillConsoleOutputCharacterW(console, ' ', lengthToEnd, info.cursorPosition(), written);
                     break;
                 default:
                     break;
@@ -206,13 +200,8 @@ public class WindowsAnsiProcessor extends AnsiProcessor {
                     int lengthToLastCol =
                             info.size().x() - info.cursorPosition().x();
                     FillConsoleOutputAttribute(
-                            console,
-                            info.attributes(),
-                            lengthToLastCol,
-                            info.cursorPosition(),
-                            written);
-                    FillConsoleOutputCharacterW(
-                            console, ' ', lengthToLastCol, info.cursorPosition(), written);
+                            console, info.attributes(), lengthToLastCol, info.cursorPosition(), written);
+                    FillConsoleOutputCharacterW(console, ' ', lengthToLastCol, info.cursorPosition(), written);
                     break;
                 default:
                     break;

--- a/src/main/java/org/fusesource/jansi/ffm/WindowsCLibrary.java
+++ b/src/main/java/org/fusesource/jansi/ffm/WindowsCLibrary.java
@@ -76,14 +76,14 @@ final class WindowsCLibrary implements AnsiConsoleSupport.CLibrary {
 
     @Override
     public int isTty(int fd) {
-        try (Arena session = Arena.ofConfined()) {
+        try (Arena arena = Arena.ofConfined()) {
             // check if fd is a pipe
             MemorySegment h = Kernel32._get_osfhandle(fd);
             int t = Kernel32.GetFileType(h);
             if (t == FILE_TYPE_CHAR) {
                 // check that this is a real tty because the /dev/null
                 // and /dev/zero streams are also of type FILE_TYPE_CHAR
-                return Kernel32.GetConsoleMode(h, session.allocate(JAVA_INT));
+                return Kernel32.GetConsoleMode(h, arena.allocate(JAVA_INT));
             }
 
             if (NtQueryObject == null) {
@@ -92,8 +92,8 @@ final class WindowsCLibrary implements AnsiConsoleSupport.CLibrary {
 
             final int BUFFER_SIZE = 1024;
 
-            MemorySegment buffer = session.allocate(BUFFER_SIZE);
-            MemorySegment result = session.allocate(JAVA_LONG);
+            MemorySegment buffer = arena.allocate(BUFFER_SIZE);
+            MemorySegment result = arena.allocate(JAVA_LONG);
 
             int res = (int) NtQueryObject.invokeExact(h, ObjectNameInformation, buffer, BUFFER_SIZE - 2, result);
             if (res != 0) {

--- a/src/main/java/org/fusesource/jansi/ffm/WindowsCLibrary.java
+++ b/src/main/java/org/fusesource/jansi/ffm/WindowsCLibrary.java
@@ -18,7 +18,6 @@ package org.fusesource.jansi.ffm;
 import java.lang.foreign.*;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.VarHandle;
-import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 
 import org.fusesource.jansi.AnsiConsoleSupport;
@@ -104,15 +103,7 @@ final class WindowsCLibrary implements AnsiConsoleSupport.CLibrary {
             int stringLength = Short.toUnsignedInt((Short) UNICODE_STRING_LENGTH.get(buffer));
             MemorySegment stringBuffer = ((MemorySegment) UNICODE_STRING_BUFFER.get(buffer)).reinterpret(stringLength);
 
-            byte[] array = new byte[stringLength];
-            MemorySegment.copy(stringBuffer, JAVA_BYTE, 0, array, 0, stringLength);
-
-            String str = new String(
-                    array,
-                    ByteOrder.nativeOrder() == ByteOrder.LITTLE_ENDIAN
-                            ? StandardCharsets.UTF_16LE
-                            : StandardCharsets.UTF_16BE);
-
+            String str = new String(stringBuffer.toArray(JAVA_BYTE), StandardCharsets.UTF_16LE).trim();
             if (str.startsWith("msys-") || str.startsWith("cygwin-") || str.startsWith("-pty")) {
                 return 1;
             }

--- a/src/main/java/org/fusesource/jansi/ffm/WindowsCLibrary.java
+++ b/src/main/java/org/fusesource/jansi/ffm/WindowsCLibrary.java
@@ -31,16 +31,11 @@ final class WindowsCLibrary implements AnsiConsoleSupport.CLibrary {
 
     private static final int ObjectNameInformation = 1;
 
-    private static final MethodHandle _get_osfhandle;
-    private static final MethodHandle GetFileType;
     private static final MethodHandle NtQueryObject;
     private static final VarHandle UNICODE_STRING_LENGTH;
     private static final VarHandle UNICODE_STRING_BUFFER;
 
     static {
-        _get_osfhandle = Kernel32.downcallHandle("_get_osfhandle", FunctionDescriptor.of(ADDRESS, JAVA_INT));
-        GetFileType = Kernel32.downcallHandle("GetFileType", FunctionDescriptor.of(JAVA_INT, ADDRESS));
-
         MethodHandle ntQueryObjectHandle = null;
         try {
             SymbolLookup ntDll = SymbolLookup.libraryLookup("ntdll", Arena.ofAuto());
@@ -84,8 +79,8 @@ final class WindowsCLibrary implements AnsiConsoleSupport.CLibrary {
     public int isTty(int fd) {
         try (Arena session = Arena.ofConfined()) {
             // check if fd is a pipe
-            MemorySegment h = (MemorySegment) _get_osfhandle.invokeExact(fd);
-            int t = (int) GetFileType.invokeExact(h);
+            MemorySegment h = Kernel32._get_osfhandle(fd);
+            int t = Kernel32.GetFileType(h);
             if (t == FILE_TYPE_CHAR) {
                 // check that this is a real tty because the /dev/null
                 // and /dev/zero streams are also of type FILE_TYPE_CHAR

--- a/src/main/java/org/fusesource/jansi/ffm/WindowsCLibrary.java
+++ b/src/main/java/org/fusesource/jansi/ffm/WindowsCLibrary.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2009-2023 the original author(s).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fusesource.jansi.ffm;
+
+import org.fusesource.jansi.AnsiConsoleSupport;
+
+final class WindowsCLibrary implements AnsiConsoleSupport.CLibrary {
+
+    @Override
+    public short getTerminalWidth(int fd) {
+        throw new UnsupportedOperationException("Windows does not support ioctl");
+    }
+
+    @Override
+    public int isTty(int fd) {
+        return 0; // TODO
+    }
+}

--- a/src/main/java/org/fusesource/jansi/ffm/WindowsCLibrary.java
+++ b/src/main/java/org/fusesource/jansi/ffm/WindowsCLibrary.java
@@ -17,7 +17,54 @@ package org.fusesource.jansi.ffm;
 
 import org.fusesource.jansi.AnsiConsoleSupport;
 
+import java.lang.foreign.*;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.VarHandle;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+
+import static java.lang.foreign.ValueLayout.*;
+
 final class WindowsCLibrary implements AnsiConsoleSupport.CLibrary {
+
+    private static final int FILE_TYPE_CHAR = 0x0002;
+
+    private static final int ObjectNameInformation = 1;
+
+    private static final MethodHandle _get_osfhandle;
+    private static final MethodHandle GetFileType;
+    private static final MethodHandle NtQueryObject;
+    private static final VarHandle UNICODE_STRING_LENGTH;
+    private static final VarHandle UNICODE_STRING_BUFFER;
+
+    static {
+        _get_osfhandle = Kernel32.downcallHandle("_get_osfhandle",
+                FunctionDescriptor.of(ADDRESS, JAVA_INT));
+        GetFileType = Kernel32.downcallHandle("GetFileType",
+                FunctionDescriptor.of(JAVA_INT, ADDRESS));
+
+        MethodHandle ntQueryObjectHandle = null;
+        try {
+            SymbolLookup ntDll = SymbolLookup.libraryLookup("ntdll", Arena.ofAuto());
+
+            ntQueryObjectHandle = ntDll.find("NtQueryObject")
+                    .map(addr -> Linker.nativeLinker().downcallHandle(addr,
+                            FunctionDescriptor.of(JAVA_INT, ADDRESS, JAVA_INT, ADDRESS, JAVA_LONG, ADDRESS)))
+                    .orElse(null);
+        } catch (Throwable ignored) {
+        }
+
+        NtQueryObject = ntQueryObjectHandle;
+
+        StructLayout unicodeStringLayout = MemoryLayout.structLayout(
+                JAVA_SHORT.withName("Length"),
+                JAVA_SHORT.withName("MaximumLength"),
+                ADDRESS.withName("Buffer")
+        );
+
+        UNICODE_STRING_LENGTH = unicodeStringLayout.varHandle(PathElement.groupElement("Length"));
+        UNICODE_STRING_BUFFER = unicodeStringLayout.varHandle(PathElement.groupElement("Buffer"));
+    }
 
     @Override
     public short getTerminalWidth(int fd) {
@@ -26,6 +73,46 @@ final class WindowsCLibrary implements AnsiConsoleSupport.CLibrary {
 
     @Override
     public int isTty(int fd) {
-        return 0; // TODO
+        try (Arena session = Arena.ofConfined()) {
+            // check if fd is a pipe
+            MemorySegment h = (MemorySegment) _get_osfhandle.invokeExact(fd);
+            int t = (int) GetFileType.invokeExact(h);
+            if (t == FILE_TYPE_CHAR) {
+                // check that this is a real tty because the /dev/null
+                // and /dev/zero streams are also of type FILE_TYPE_CHAR
+                return Kernel32.GetConsoleMode(h, MemorySegment.NULL);
+            }
+
+            if (NtQueryObject == null) {
+                return 0;
+            }
+
+            final int BUFFER_SIZE = 1024;
+
+            MemorySegment buffer = session.allocate(BUFFER_SIZE);
+            MemorySegment result = session.allocate(JAVA_LONG);
+
+            int res = (int) NtQueryObject.invokeExact(h, ObjectNameInformation, buffer, BUFFER_SIZE - 2, result);
+            if (res != 0) {
+                return 0;
+            }
+
+            int stringLength = Short.toUnsignedInt((Short) UNICODE_STRING_LENGTH.get(buffer));
+            MemorySegment stringBuffer = ((MemorySegment) UNICODE_STRING_BUFFER.get(buffer)).reinterpret(stringLength);
+
+            byte[] array = new byte[stringLength];
+            MemorySegment.copy(stringBuffer, JAVA_BYTE, 0, array, 0, stringLength);
+
+            String str = new String(array,
+                    ByteOrder.nativeOrder() == ByteOrder.LITTLE_ENDIAN ? StandardCharsets.UTF_16LE : StandardCharsets.UTF_16BE);
+
+            if (str.startsWith("msys-") || str.startsWith("cygwin-") || str.startsWith("-pty")) {
+                return 1;
+            }
+
+            return 0;
+        } catch (Throwable e) {
+            throw new AssertionError("should not reach here", e);
+        }
     }
 }

--- a/src/main/java/org/fusesource/jansi/internal/OSInfo.java
+++ b/src/main/java/org/fusesource/jansi/internal/OSInfo.java
@@ -120,6 +120,10 @@ public class OSInfo {
         return translateOSNameToFolderName(System.getProperty("os.name"));
     }
 
+    public static boolean isWindows() {
+        return System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("win");
+    }
+
     public static boolean isAndroid() {
         return System.getProperty("java.runtime.name", "").toLowerCase().contains("android");
     }

--- a/src/main/java/org/fusesource/jansi/internal/OSInfo.java
+++ b/src/main/java/org/fusesource/jansi/internal/OSInfo.java
@@ -125,7 +125,7 @@ public class OSInfo {
     }
 
     public static boolean isAndroid() {
-        return System.getProperty("java.runtime.name", "").toLowerCase().contains("android");
+        return System.getProperty("java.runtime.name", "").toLowerCase(Locale.ROOT).contains("android");
     }
 
     public static boolean isAlpine() {
@@ -135,7 +135,7 @@ public class OSInfo {
 
             InputStream in = p.getInputStream();
             try {
-                return readFully(in).toLowerCase().contains("alpine");
+                return readFully(in).toLowerCase(Locale.ROOT).contains("alpine");
             } finally {
                 in.close();
             }

--- a/src/main/java/org/fusesource/jansi/internal/OSInfo.java
+++ b/src/main/java/org/fusesource/jansi/internal/OSInfo.java
@@ -211,7 +211,7 @@ public class OSInfo {
         if (osArch.startsWith("arm")) {
             osArch = resolveArmArchType();
         } else {
-            String lc = osArch.toLowerCase(Locale.US);
+            String lc = osArch.toLowerCase(Locale.ROOT);
             if (archMapping.containsKey(lc)) return archMapping.get(lc);
         }
         return translateArchNameToFolderName(osArch);

--- a/src/main/java/org/fusesource/jansi/internal/OSInfo.java
+++ b/src/main/java/org/fusesource/jansi/internal/OSInfo.java
@@ -125,7 +125,9 @@ public class OSInfo {
     }
 
     public static boolean isAndroid() {
-        return System.getProperty("java.runtime.name", "").toLowerCase(Locale.ROOT).contains("android");
+        return System.getProperty("java.runtime.name", "")
+                .toLowerCase(Locale.ROOT)
+                .contains("android");
     }
 
     public static boolean isAlpine() {


### PR DESCRIPTION
The FFM backend appears to be untested and will crash when using it, I'm trying to solve these problems.

* Avoid lookup `ioctl` and `isatty` on Windows;
* Make `SYMBOL_LOOKUP` initialized earlier to avoid NPE
* Fix wrong alignment;
* Load Kernel32;
* Fix incorrect type conversion;
* Impl CLibrary for Windows;
* Fix string encoding;

There are more issues waiting to be fixed, WIP.