### PR TITLE
Refactoring AnsiConsoleSupport

### DIFF
--- a/src/main/java/org/fusesource/jansi/AnsiConsole.java
+++ b/src/main/java/org/fusesource/jansi/AnsiConsole.java
@@ -25,6 +25,7 @@ import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
 import java.nio.charset.UnsupportedCharsetException;
 
+import org.fusesource.jansi.internal.AnsiConsoleSupport;
 import org.fusesource.jansi.internal.OSInfo;
 import org.fusesource.jansi.io.AnsiOutputStream;
 import org.fusesource.jansi.io.AnsiProcessor;

--- a/src/main/java/org/fusesource/jansi/AnsiConsole.java
+++ b/src/main/java/org/fusesource/jansi/AnsiConsole.java
@@ -157,8 +157,20 @@ public class AnsiConsole {
      */
     public static final String JANSI_GRACEFUL = "jansi.graceful";
 
+    /**
+     * The {@code jansi.providers} system property can be set to control which internal provider
+     * will be used.  If this property is not set, the {@code ffm} provider will be used if available,
+     * else the {@code jni} one will be used.  If set, this property is interpreted as a comma
+     * separated list of provider names to try in order.
+     */
     public static final String JANSI_PROVIDERS = "jansi.providers";
+    /**
+     * The name of the {@code jni} provider.
+     */
     public static final String JANSI_PROVIDER_JNI = "jni";
+    /**
+     * The name of the {@code ffm} provider.
+     */
     public static final String JANSI_PROVIDER_FFM = "ffm";
 
     /**

--- a/src/main/java/org/fusesource/jansi/AnsiConsole.java
+++ b/src/main/java/org/fusesource/jansi/AnsiConsole.java
@@ -25,7 +25,7 @@ import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
 import java.nio.charset.UnsupportedCharsetException;
 
-import org.fusesource.jansi.internal.AnsiConsoleSupport;
+import org.fusesource.jansi.internal.AnsiConsoleSupportHolder;
 import org.fusesource.jansi.internal.OSInfo;
 import org.fusesource.jansi.io.AnsiOutputStream;
 import org.fusesource.jansi.io.AnsiProcessor;
@@ -158,7 +158,6 @@ public class AnsiConsole {
     public static final String JANSI_PROVIDERS = "jansi.providers";
     public static final String JANSI_PROVIDER_JNI = "jni";
     public static final String JANSI_PROVIDER_FFM = "ffm";
-    public static final String JANSI_PROVIDERS_DEFAULT = JANSI_PROVIDER_FFM + "," + JANSI_PROVIDER_JNI;
 
     /**
      * @deprecated this field will be made private in a future release, use {@link #sysOut()} instead
@@ -243,7 +242,7 @@ public class AnsiConsole {
         try {
             // If we can detect that stdout is not a tty, then setup
             // to strip the ANSI sequences...
-            isAtty = getCLibrary().isTty(fd) != 0;
+            isAtty = AnsiConsoleSupportHolder.getCLibrary().isTty(fd) != 0;
             String term = System.getenv("TERM");
             String emacs = System.getenv("INSIDE_EMACS");
             if (isAtty && "dumb".equals(term) && emacs != null && !emacs.contains("comint")) {
@@ -269,26 +268,30 @@ public class AnsiConsole {
             installer = uninstaller = null;
             width = new AnsiOutputStream.ZeroWidthSupplier();
         } else if (IS_WINDOWS) {
-            final long console = getKernel32().getStdHandle(stdout);
+            final long console = AnsiConsoleSupportHolder.getKernel32().getStdHandle(stdout);
             final int[] mode = new int[1];
-            final boolean isConsole = getKernel32().getConsoleMode(console, mode) != 0;
-            if (isConsole && getKernel32().setConsoleMode(console, mode[0] | ENABLE_VIRTUAL_TERMINAL_PROCESSING) != 0) {
+            final boolean isConsole = AnsiConsoleSupportHolder.getKernel32().getConsoleMode(console, mode) != 0;
+            if (isConsole
+                    && AnsiConsoleSupportHolder.getKernel32()
+                                    .setConsoleMode(console, mode[0] | ENABLE_VIRTUAL_TERMINAL_PROCESSING)
+                            != 0) {
                 // set it back for now, but we know it works
-                getKernel32().setConsoleMode(console, mode[0]);
+                AnsiConsoleSupportHolder.getKernel32().setConsoleMode(console, mode[0]);
                 processor = null;
                 type = AnsiType.VirtualTerminal;
                 installer = new AnsiOutputStream.IoRunnable() {
                     @Override
                     public void run() throws IOException {
                         virtualProcessing++;
-                        getKernel32().setConsoleMode(console, mode[0] | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
+                        AnsiConsoleSupportHolder.getKernel32()
+                                .setConsoleMode(console, mode[0] | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
                     }
                 };
                 uninstaller = new AnsiOutputStream.IoRunnable() {
                     @Override
                     public void run() throws IOException {
                         if (--virtualProcessing == 0) {
-                            getKernel32().setConsoleMode(console, mode[0]);
+                            AnsiConsoleSupportHolder.getKernel32().setConsoleMode(console, mode[0]);
                         }
                     }
                 };
@@ -304,7 +307,7 @@ public class AnsiConsole {
                 AnsiProcessor proc;
                 AnsiType ttype;
                 try {
-                    proc = getKernel32().newProcessor(out, console);
+                    proc = AnsiConsoleSupportHolder.getKernel32().newProcessor(out, console);
                     ttype = AnsiType.Emulation;
                 } catch (Throwable ignore) {
                     // this happens when the stdout is being redirected to a file.
@@ -316,7 +319,7 @@ public class AnsiConsole {
                 type = ttype;
                 installer = uninstaller = null;
             }
-            width = () -> getKernel32().getTerminalWidth(console);
+            width = () -> AnsiConsoleSupportHolder.getKernel32().getTerminalWidth(console);
         }
 
         // We must be on some Unix variant...
@@ -325,7 +328,7 @@ public class AnsiConsole {
             processor = null;
             type = AnsiType.Native;
             installer = uninstaller = null;
-            width = () -> getCLibrary().getTerminalWidth(fd);
+            width = () -> AnsiConsoleSupportHolder.getCLibrary().getTerminalWidth(fd);
         }
 
         AnsiMode mode;
@@ -534,13 +537,5 @@ public class AnsiConsole {
             err = ansiStream(false);
             initialized = true;
         }
-    }
-
-    private static AnsiConsoleSupport.Kernel32 getKernel32() {
-        return AnsiConsoleSupport.getInstance().getKernel32();
-    }
-
-    private static AnsiConsoleSupport.CLibrary getCLibrary() {
-        return AnsiConsoleSupport.getInstance().getCLibrary();
     }
 }

--- a/src/main/java/org/fusesource/jansi/AnsiMain.java
+++ b/src/main/java/org/fusesource/jansi/AnsiMain.java
@@ -27,6 +27,7 @@ import java.util.Properties;
 
 import org.fusesource.jansi.Ansi.Attribute;
 import org.fusesource.jansi.internal.AnsiConsoleSupport;
+import org.fusesource.jansi.internal.AnsiConsoleSupportHolder;
 import org.fusesource.jansi.internal.JansiLoader;
 
 import static org.fusesource.jansi.Ansi.ansi;
@@ -54,9 +55,8 @@ public class AnsiMain {
 
         System.out.println();
 
-        System.out.println("jansi.providers= "
-                + System.getProperty(AnsiConsole.JANSI_PROVIDERS, AnsiConsole.JANSI_PROVIDERS_DEFAULT));
-        String provider = AnsiConsoleSupport.getInstance().getProviderName();
+        System.out.println("jansi.providers= " + System.getProperty(AnsiConsole.JANSI_PROVIDERS, ""));
+        String provider = AnsiConsoleSupportHolder.getProviderName();
         System.out.println("Selected provider: " + provider);
 
         if (AnsiConsole.JANSI_PROVIDER_JNI.equals(provider)) {
@@ -202,13 +202,13 @@ public class AnsiMain {
         int isatty;
         int width;
         if (AnsiConsole.IS_WINDOWS) {
-            long console = AnsiConsoleSupport.getInstance().getKernel32().getStdHandle(!stderr);
-            isatty = AnsiConsoleSupport.getInstance().getKernel32().isTty(console);
-            width = AnsiConsoleSupport.getInstance().getKernel32().getTerminalWidth(console);
+            long console = AnsiConsoleSupportHolder.getKernel32().getStdHandle(!stderr);
+            isatty = AnsiConsoleSupportHolder.getKernel32().isTty(console);
+            width = AnsiConsoleSupportHolder.getKernel32().getTerminalWidth(console);
         } else {
             int fd = stderr ? AnsiConsoleSupport.CLibrary.STDERR_FILENO : AnsiConsoleSupport.CLibrary.STDOUT_FILENO;
-            isatty = AnsiConsoleSupport.getInstance().getCLibrary().isTty(fd);
-            width = AnsiConsoleSupport.getInstance().getCLibrary().getTerminalWidth(fd);
+            isatty = AnsiConsoleSupportHolder.getCLibrary().isTty(fd);
+            width = AnsiConsoleSupportHolder.getCLibrary().getTerminalWidth(fd);
         }
 
         System.out.println("isatty(STD" + (stderr ? "ERR" : "OUT") + "_FILENO): " + isatty + ", System."

--- a/src/main/java/org/fusesource/jansi/AnsiMain.java
+++ b/src/main/java/org/fusesource/jansi/AnsiMain.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.PrintStream;
-import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 
 import org.fusesource.jansi.Ansi.Attribute;
@@ -218,7 +217,7 @@ public class AnsiMain {
                     width = 0;
                 }
             } else {
-                width = AnsiConsoleSupport.getInstance().getKernel32().getTerminalWidth(console);
+                width = AnsiConsoleSupportHolder.getKernel32().getTerminalWidth(console);
             }
         } else {
             int fd = stderr ? AnsiConsoleSupport.CLibrary.STDERR_FILENO : AnsiConsoleSupport.CLibrary.STDOUT_FILENO;

--- a/src/main/java/org/fusesource/jansi/AnsiMain.java
+++ b/src/main/java/org/fusesource/jansi/AnsiMain.java
@@ -26,6 +26,7 @@ import java.io.PrintStream;
 import java.util.Properties;
 
 import org.fusesource.jansi.Ansi.Attribute;
+import org.fusesource.jansi.internal.AnsiConsoleSupport;
 import org.fusesource.jansi.internal.JansiLoader;
 
 import static org.fusesource.jansi.Ansi.ansi;

--- a/src/main/java/org/fusesource/jansi/WindowsSupport.java
+++ b/src/main/java/org/fusesource/jansi/WindowsSupport.java
@@ -15,20 +15,16 @@
  */
 package org.fusesource.jansi;
 
-import org.fusesource.jansi.internal.AnsiConsoleSupport;
+import org.fusesource.jansi.internal.AnsiConsoleSupportHolder;
 
 public class WindowsSupport {
 
     public static String getLastErrorMessage() {
-        int errorCode = getKernel32().getLastError();
+        int errorCode = AnsiConsoleSupportHolder.getKernel32().getLastError();
         return getErrorMessage(errorCode);
     }
 
     public static String getErrorMessage(int errorCode) {
-        return getKernel32().getErrorMessage(errorCode);
-    }
-
-    private static AnsiConsoleSupport.Kernel32 getKernel32() {
-        return AnsiConsoleSupport.getInstance().getKernel32();
+        return AnsiConsoleSupportHolder.getKernel32().getErrorMessage(errorCode);
     }
 }

--- a/src/main/java/org/fusesource/jansi/WindowsSupport.java
+++ b/src/main/java/org/fusesource/jansi/WindowsSupport.java
@@ -15,6 +15,8 @@
  */
 package org.fusesource.jansi;
 
+import org.fusesource.jansi.internal.AnsiConsoleSupport;
+
 public class WindowsSupport {
 
     public static String getLastErrorMessage() {

--- a/src/main/java/org/fusesource/jansi/internal/AnsiConsoleSupport.java
+++ b/src/main/java/org/fusesource/jansi/internal/AnsiConsoleSupport.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.fusesource.jansi;
+package org.fusesource.jansi.internal;
 
 import java.io.IOException;
 import java.io.OutputStream;

--- a/src/main/java/org/fusesource/jansi/internal/AnsiConsoleSupport.java
+++ b/src/main/java/org/fusesource/jansi/internal/AnsiConsoleSupport.java
@@ -56,8 +56,4 @@ public interface AnsiConsoleSupport {
     CLibrary getCLibrary();
 
     Kernel32 getKernel32();
-
-    static AnsiConsoleSupport getInstance() {
-        return AnsiConsoleSupportHolder.get();
-    }
 }

--- a/src/main/java/org/fusesource/jansi/internal/AnsiConsoleSupportHolder.java
+++ b/src/main/java/org/fusesource/jansi/internal/AnsiConsoleSupportHolder.java
@@ -24,16 +24,13 @@ public final class AnsiConsoleSupportHolder {
     private static final AnsiConsoleSupport.Kernel32 KERNEL32;
     private static final Throwable ERR;
 
-    private static Class<?> findProviderClass(String provider) throws ClassNotFoundException {
-        return Class.forName("org.fusesource.jansi.internal." + provider + ".AnsiConsoleSupportImpl");
-    }
-
     private static AnsiConsoleSupport getDefaultProvider() {
         try {
             // Call the specialized constructor to check whether the module has native access enabled
             // If not, fallback to JNI to avoid the JDK printing warnings in stderr
-            return (AnsiConsoleSupport)
-                    findProviderClass("ffm").getConstructor(boolean.class).newInstance(true);
+            return (AnsiConsoleSupport) Class.forName("org.fusesource.jansi.internal.ffm.AnsiConsoleSupportImpl")
+                    .getConstructor(boolean.class)
+                    .newInstance(true);
         } catch (Throwable ignored) {
         }
 
@@ -48,7 +45,9 @@ public final class AnsiConsoleSupportHolder {
         for (String provider : providers) {
             try {
                 return (AnsiConsoleSupport)
-                        findProviderClass(provider).getConstructor().newInstance();
+                        Class.forName("org.fusesource.jansi.internal." + provider + ".AnsiConsoleSupportImpl")
+                                .getConstructor()
+                                .newInstance();
             } catch (Throwable t) {
                 if (error == null) {
                     error = new RuntimeException("Unable to create AnsiConsoleSupport provider");

--- a/src/main/java/org/fusesource/jansi/internal/AnsiConsoleSupportHolder.java
+++ b/src/main/java/org/fusesource/jansi/internal/AnsiConsoleSupportHolder.java
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.fusesource.jansi;
+package org.fusesource.jansi.internal;
 
-import org.fusesource.jansi.internal.AnsiConsoleSupportJni;
+import org.fusesource.jansi.internal.jni.AnsiConsoleSupportJni;
 
 import static org.fusesource.jansi.AnsiConsole.JANSI_PROVIDERS;
 import static org.fusesource.jansi.AnsiConsole.JANSI_PROVIDERS_DEFAULT;
@@ -45,7 +45,7 @@ class AnsiConsoleSupportHolder {
                 if (JANSI_PROVIDER_FFM.equals(provider)) {
                     return (AnsiConsoleSupport) AnsiConsoleSupport.class
                             .getClassLoader()
-                            .loadClass("org.fusesource.jansi.ffm.AnsiConsoleSupportFfm")
+                            .loadClass("org.fusesource.jansi.internal.ffm.AnsiConsoleSupportFfm")
                             .getConstructor()
                             .newInstance();
                 } else if (JANSI_PROVIDER_JNI.equals(provider)) {

--- a/src/main/java/org/fusesource/jansi/internal/ffm/AnsiConsoleSupportFfm.java
+++ b/src/main/java/org/fusesource/jansi/internal/ffm/AnsiConsoleSupportFfm.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.fusesource.jansi.ffm;
+package org.fusesource.jansi.internal.ffm;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -21,11 +21,9 @@ import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 
-import org.fusesource.jansi.AnsiConsoleSupport;
+import org.fusesource.jansi.internal.AnsiConsoleSupport;
 import org.fusesource.jansi.internal.OSInfo;
 import org.fusesource.jansi.io.AnsiProcessor;
-
-import static org.fusesource.jansi.ffm.Kernel32.*;
 
 public class AnsiConsoleSupportFfm implements AnsiConsoleSupport {
     @Override
@@ -54,15 +52,15 @@ public class AnsiConsoleSupportFfm implements AnsiConsoleSupport {
             @Override
             public int getTerminalWidth(long console) {
                 try (Arena arena = Arena.ofConfined()) {
-                    CONSOLE_SCREEN_BUFFER_INFO info = new CONSOLE_SCREEN_BUFFER_INFO(arena);
-                    GetConsoleScreenBufferInfo(MemorySegment.ofAddress(console), info);
+                    org.fusesource.jansi.internal.ffm.Kernel32.CONSOLE_SCREEN_BUFFER_INFO info = new org.fusesource.jansi.internal.ffm.Kernel32.CONSOLE_SCREEN_BUFFER_INFO(arena);
+                    org.fusesource.jansi.internal.ffm.Kernel32.GetConsoleScreenBufferInfo(MemorySegment.ofAddress(console), info);
                     return info.windowWidth();
                 }
             }
 
             @Override
             public long getStdHandle(boolean stdout) {
-                return GetStdHandle(stdout ? STD_OUTPUT_HANDLE : STD_ERROR_HANDLE)
+                return org.fusesource.jansi.internal.ffm.Kernel32.GetStdHandle(stdout ? org.fusesource.jansi.internal.ffm.Kernel32.STD_OUTPUT_HANDLE : org.fusesource.jansi.internal.ffm.Kernel32.STD_ERROR_HANDLE)
                         .address();
             }
 
@@ -70,7 +68,7 @@ public class AnsiConsoleSupportFfm implements AnsiConsoleSupport {
             public int getConsoleMode(long console, int[] mode) {
                 try (Arena arena = Arena.ofConfined()) {
                     MemorySegment written = arena.allocate(ValueLayout.JAVA_INT);
-                    int res = GetConsoleMode(MemorySegment.ofAddress(console), written);
+                    int res = org.fusesource.jansi.internal.ffm.Kernel32.GetConsoleMode(MemorySegment.ofAddress(console), written);
                     mode[0] = written.getAtIndex(ValueLayout.JAVA_INT, 0);
                     return res;
                 }
@@ -78,17 +76,17 @@ public class AnsiConsoleSupportFfm implements AnsiConsoleSupport {
 
             @Override
             public int setConsoleMode(long console, int mode) {
-                return SetConsoleMode(MemorySegment.ofAddress(console), mode);
+                return org.fusesource.jansi.internal.ffm.Kernel32.SetConsoleMode(MemorySegment.ofAddress(console), mode);
             }
 
             @Override
             public int getLastError() {
-                return GetLastError();
+                return org.fusesource.jansi.internal.ffm.Kernel32.GetLastError();
             }
 
             @Override
             public String getErrorMessage(int errorCode) {
-                return org.fusesource.jansi.ffm.Kernel32.getErrorMessage(errorCode);
+                return org.fusesource.jansi.internal.ffm.Kernel32.getErrorMessage(errorCode);
             }
 
             @Override

--- a/src/main/java/org/fusesource/jansi/internal/ffm/AnsiConsoleSupportImpl.java
+++ b/src/main/java/org/fusesource/jansi/internal/ffm/AnsiConsoleSupportImpl.java
@@ -27,7 +27,16 @@ import org.fusesource.jansi.io.AnsiProcessor;
 
 import static org.fusesource.jansi.internal.ffm.Kernel32.*;
 
-public class AnsiConsoleSupportImpl implements AnsiConsoleSupport {
+public final class AnsiConsoleSupportImpl implements AnsiConsoleSupport {
+
+    public AnsiConsoleSupportImpl() {}
+
+    public AnsiConsoleSupportImpl(boolean checkNativeAccess) {
+        if (checkNativeAccess && !AnsiConsoleSupportImpl.class.getModule().isNativeAccessEnabled()) {
+            throw new UnsupportedOperationException("Native access is not enabled for the current module");
+        }
+    }
+
     @Override
     public String getProviderName() {
         return "ffm";

--- a/src/main/java/org/fusesource/jansi/internal/ffm/AnsiConsoleSupportImpl.java
+++ b/src/main/java/org/fusesource/jansi/internal/ffm/AnsiConsoleSupportImpl.java
@@ -25,7 +25,17 @@ import org.fusesource.jansi.internal.AnsiConsoleSupport;
 import org.fusesource.jansi.internal.OSInfo;
 import org.fusesource.jansi.io.AnsiProcessor;
 
-public class AnsiConsoleSupportFfm implements AnsiConsoleSupport {
+@SuppressWarnings("unused") // Load using reflection
+public final class AnsiConsoleSupportImpl implements AnsiConsoleSupport {
+
+    public AnsiConsoleSupportImpl() {}
+
+    public AnsiConsoleSupportImpl(boolean checkNativeAccess) {
+        if (checkNativeAccess && !AnsiConsoleSupportImpl.class.getModule().isNativeAccessEnabled()) {
+            throw new UnsupportedOperationException("Native access is not enabled for the current module");
+        }
+    }
+
     @Override
     public String getProviderName() {
         return "ffm";
@@ -52,15 +62,20 @@ public class AnsiConsoleSupportFfm implements AnsiConsoleSupport {
             @Override
             public int getTerminalWidth(long console) {
                 try (Arena arena = Arena.ofConfined()) {
-                    org.fusesource.jansi.internal.ffm.Kernel32.CONSOLE_SCREEN_BUFFER_INFO info = new org.fusesource.jansi.internal.ffm.Kernel32.CONSOLE_SCREEN_BUFFER_INFO(arena);
-                    org.fusesource.jansi.internal.ffm.Kernel32.GetConsoleScreenBufferInfo(MemorySegment.ofAddress(console), info);
+                    org.fusesource.jansi.internal.ffm.Kernel32.CONSOLE_SCREEN_BUFFER_INFO info =
+                            new org.fusesource.jansi.internal.ffm.Kernel32.CONSOLE_SCREEN_BUFFER_INFO(arena);
+                    org.fusesource.jansi.internal.ffm.Kernel32.GetConsoleScreenBufferInfo(
+                            MemorySegment.ofAddress(console), info);
                     return info.windowWidth();
                 }
             }
 
             @Override
             public long getStdHandle(boolean stdout) {
-                return org.fusesource.jansi.internal.ffm.Kernel32.GetStdHandle(stdout ? org.fusesource.jansi.internal.ffm.Kernel32.STD_OUTPUT_HANDLE : org.fusesource.jansi.internal.ffm.Kernel32.STD_ERROR_HANDLE)
+                return org.fusesource.jansi.internal.ffm.Kernel32.GetStdHandle(
+                                stdout
+                                        ? org.fusesource.jansi.internal.ffm.Kernel32.STD_OUTPUT_HANDLE
+                                        : org.fusesource.jansi.internal.ffm.Kernel32.STD_ERROR_HANDLE)
                         .address();
             }
 
@@ -68,7 +83,8 @@ public class AnsiConsoleSupportFfm implements AnsiConsoleSupport {
             public int getConsoleMode(long console, int[] mode) {
                 try (Arena arena = Arena.ofConfined()) {
                     MemorySegment written = arena.allocate(ValueLayout.JAVA_INT);
-                    int res = org.fusesource.jansi.internal.ffm.Kernel32.GetConsoleMode(MemorySegment.ofAddress(console), written);
+                    int res = org.fusesource.jansi.internal.ffm.Kernel32.GetConsoleMode(
+                            MemorySegment.ofAddress(console), written);
                     mode[0] = written.getAtIndex(ValueLayout.JAVA_INT, 0);
                     return res;
                 }
@@ -76,7 +92,8 @@ public class AnsiConsoleSupportFfm implements AnsiConsoleSupport {
 
             @Override
             public int setConsoleMode(long console, int mode) {
-                return org.fusesource.jansi.internal.ffm.Kernel32.SetConsoleMode(MemorySegment.ofAddress(console), mode);
+                return org.fusesource.jansi.internal.ffm.Kernel32.SetConsoleMode(
+                        MemorySegment.ofAddress(console), mode);
             }
 
             @Override

--- a/src/main/java/org/fusesource/jansi/internal/ffm/Kernel32.java
+++ b/src/main/java/org/fusesource/jansi/internal/ffm/Kernel32.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.fusesource.jansi.ffm;
+package org.fusesource.jansi.internal.ffm;
 
 import java.io.IOException;
 import java.lang.foreign.AddressLayout;

--- a/src/main/java/org/fusesource/jansi/internal/ffm/Kernel32.java
+++ b/src/main/java/org/fusesource/jansi/internal/ffm/Kernel32.java
@@ -309,7 +309,8 @@ final class Kernel32 {
         int bufferSize = 160;
         try (Arena arena = Arena.ofConfined()) {
             MemorySegment data = arena.allocate(bufferSize);
-            FormatMessageW(FORMAT_MESSAGE_FROM_SYSTEM, null, errorCode, 0, data, bufferSize, null);
+            FormatMessageW(
+                    FORMAT_MESSAGE_FROM_SYSTEM, MemorySegment.NULL, errorCode, 0, data, bufferSize, MemorySegment.NULL);
             return new String(data.toArray(JAVA_BYTE), StandardCharsets.UTF_16LE).trim();
         }
     }

--- a/src/main/java/org/fusesource/jansi/internal/ffm/PosixCLibrary.java
+++ b/src/main/java/org/fusesource/jansi/internal/ffm/PosixCLibrary.java
@@ -13,13 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.fusesource.jansi.ffm;
+package org.fusesource.jansi.internal.ffm;
 
 import java.lang.foreign.*;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.VarHandle;
 
-import org.fusesource.jansi.AnsiConsoleSupport;
+import org.fusesource.jansi.internal.AnsiConsoleSupport;
 
 final class PosixCLibrary implements AnsiConsoleSupport.CLibrary {
     private static final int TIOCGWINSZ;

--- a/src/main/java/org/fusesource/jansi/internal/ffm/WindowsAnsiProcessor.java
+++ b/src/main/java/org/fusesource/jansi/internal/ffm/WindowsAnsiProcessor.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.fusesource.jansi.ffm;
+package org.fusesource.jansi.internal.ffm;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -25,8 +25,6 @@ import java.nio.charset.StandardCharsets;
 import org.fusesource.jansi.WindowsSupport;
 import org.fusesource.jansi.io.AnsiProcessor;
 import org.fusesource.jansi.io.Colors;
-
-import static org.fusesource.jansi.ffm.Kernel32.*;
 
 /**
  * A Windows ANSI escape processor, that uses JNA to access native platform
@@ -44,23 +42,23 @@ public class WindowsAnsiProcessor extends AnsiProcessor {
     private final MemorySegment console;
 
     private static final short FOREGROUND_BLACK = 0;
-    private static final short FOREGROUND_YELLOW = (short) (FOREGROUND_RED | FOREGROUND_GREEN);
-    private static final short FOREGROUND_MAGENTA = (short) (FOREGROUND_BLUE | FOREGROUND_RED);
-    private static final short FOREGROUND_CYAN = (short) (FOREGROUND_BLUE | FOREGROUND_GREEN);
-    private static final short FOREGROUND_WHITE = (short) (FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE);
+    private static final short FOREGROUND_YELLOW = (short) (Kernel32.FOREGROUND_RED | Kernel32.FOREGROUND_GREEN);
+    private static final short FOREGROUND_MAGENTA = (short) (Kernel32.FOREGROUND_BLUE | Kernel32.FOREGROUND_RED);
+    private static final short FOREGROUND_CYAN = (short) (Kernel32.FOREGROUND_BLUE | Kernel32.FOREGROUND_GREEN);
+    private static final short FOREGROUND_WHITE = (short) (Kernel32.FOREGROUND_RED | Kernel32.FOREGROUND_GREEN | Kernel32.FOREGROUND_BLUE);
 
     private static final short BACKGROUND_BLACK = 0;
-    private static final short BACKGROUND_YELLOW = (short) (BACKGROUND_RED | BACKGROUND_GREEN);
-    private static final short BACKGROUND_MAGENTA = (short) (BACKGROUND_BLUE | BACKGROUND_RED);
-    private static final short BACKGROUND_CYAN = (short) (BACKGROUND_BLUE | BACKGROUND_GREEN);
-    private static final short BACKGROUND_WHITE = (short) (BACKGROUND_RED | BACKGROUND_GREEN | BACKGROUND_BLUE);
+    private static final short BACKGROUND_YELLOW = (short) (Kernel32.BACKGROUND_RED | Kernel32.BACKGROUND_GREEN);
+    private static final short BACKGROUND_MAGENTA = (short) (Kernel32.BACKGROUND_BLUE | Kernel32.BACKGROUND_RED);
+    private static final short BACKGROUND_CYAN = (short) (Kernel32.BACKGROUND_BLUE | Kernel32.BACKGROUND_GREEN);
+    private static final short BACKGROUND_WHITE = (short) (Kernel32.BACKGROUND_RED | Kernel32.BACKGROUND_GREEN | Kernel32.BACKGROUND_BLUE);
 
     private static final short[] ANSI_FOREGROUND_COLOR_MAP = {
         FOREGROUND_BLACK,
-        FOREGROUND_RED,
-        FOREGROUND_GREEN,
+        Kernel32.FOREGROUND_RED,
+        Kernel32.FOREGROUND_GREEN,
         FOREGROUND_YELLOW,
-        FOREGROUND_BLUE,
+        Kernel32.FOREGROUND_BLUE,
         FOREGROUND_MAGENTA,
         FOREGROUND_CYAN,
         FOREGROUND_WHITE,
@@ -68,16 +66,16 @@ public class WindowsAnsiProcessor extends AnsiProcessor {
 
     private static final short[] ANSI_BACKGROUND_COLOR_MAP = {
         BACKGROUND_BLACK,
-        BACKGROUND_RED,
-        BACKGROUND_GREEN,
+        Kernel32.BACKGROUND_RED,
+        Kernel32.BACKGROUND_GREEN,
         BACKGROUND_YELLOW,
-        BACKGROUND_BLUE,
+        Kernel32.BACKGROUND_BLUE,
         BACKGROUND_MAGENTA,
         BACKGROUND_CYAN,
         BACKGROUND_WHITE,
     };
 
-    private final CONSOLE_SCREEN_BUFFER_INFO info = new CONSOLE_SCREEN_BUFFER_INFO(Arena.ofAuto());
+    private final Kernel32.CONSOLE_SCREEN_BUFFER_INFO info = new Kernel32.CONSOLE_SCREEN_BUFFER_INFO(Arena.ofAuto());
     private final short originalColors;
 
     private boolean negative;
@@ -92,7 +90,7 @@ public class WindowsAnsiProcessor extends AnsiProcessor {
     }
 
     public WindowsAnsiProcessor(OutputStream ps, boolean stdout) throws IOException {
-        this(ps, GetStdHandle(stdout ? STD_OUTPUT_HANDLE : STD_ERROR_HANDLE));
+        this(ps, Kernel32.GetStdHandle(stdout ? Kernel32.STD_OUTPUT_HANDLE : Kernel32.STD_ERROR_HANDLE));
     }
 
     public WindowsAnsiProcessor(OutputStream ps) throws IOException {
@@ -101,7 +99,7 @@ public class WindowsAnsiProcessor extends AnsiProcessor {
 
     private void getConsoleInfo() throws IOException {
         os.flush();
-        if (GetConsoleScreenBufferInfo(console, info) == 0) {
+        if (Kernel32.GetConsoleScreenBufferInfo(console, info) == 0) {
             throw new IOException("Could not get the screen info: " + WindowsSupport.getLastErrorMessage());
         }
         if (negative) {
@@ -115,7 +113,7 @@ public class WindowsAnsiProcessor extends AnsiProcessor {
         if (negative) {
             attributes = invertAttributeColors(attributes);
         }
-        if (SetConsoleTextAttribute(console, attributes) == 0) {
+        if (Kernel32.SetConsoleTextAttribute(console, attributes) == 0) {
             throw new IOException(WindowsSupport.getLastErrorMessage());
         }
     }
@@ -131,7 +129,7 @@ public class WindowsAnsiProcessor extends AnsiProcessor {
     }
 
     private void applyCursorPosition() throws IOException {
-        if (SetConsoleCursorPosition(console, info.cursorPosition()) == 0) {
+        if (Kernel32.SetConsoleCursorPosition(console, info.cursorPosition()) == 0) {
             throw new IOException(WindowsSupport.getLastErrorMessage());
         }
     }
@@ -143,31 +141,31 @@ public class WindowsAnsiProcessor extends AnsiProcessor {
             MemorySegment written = arena.allocate(ValueLayout.JAVA_INT);
             switch (eraseOption) {
                 case ERASE_SCREEN:
-                    COORD topLeft = new COORD(arena);
+                    Kernel32.COORD topLeft = new Kernel32.COORD(arena);
                     topLeft.x((short) 0);
                     topLeft.y(info.window().top());
                     int screenLength = info.window().height() * info.size().x();
-                    FillConsoleOutputAttribute(console, info.attributes(), screenLength, topLeft, written);
-                    FillConsoleOutputCharacterW(console, ' ', screenLength, topLeft, written);
+                    Kernel32.FillConsoleOutputAttribute(console, info.attributes(), screenLength, topLeft, written);
+                    Kernel32.FillConsoleOutputCharacterW(console, ' ', screenLength, topLeft, written);
                     break;
                 case ERASE_SCREEN_TO_BEGINING:
-                    COORD topLeft2 = new COORD(arena);
+                    Kernel32.COORD topLeft2 = new Kernel32.COORD(arena);
                     topLeft2.x((short) 0);
                     topLeft2.y(info.window().top());
                     int lengthToCursor =
                             (info.cursorPosition().y() - info.window().top())
                                             * info.size().x()
                                     + info.cursorPosition().x();
-                    FillConsoleOutputAttribute(console, info.attributes(), lengthToCursor, topLeft2, written);
-                    FillConsoleOutputCharacterW(console, ' ', lengthToCursor, topLeft2, written);
+                    Kernel32.FillConsoleOutputAttribute(console, info.attributes(), lengthToCursor, topLeft2, written);
+                    Kernel32.FillConsoleOutputCharacterW(console, ' ', lengthToCursor, topLeft2, written);
                     break;
                 case ERASE_SCREEN_TO_END:
                     int lengthToEnd =
                             (info.window().bottom() - info.cursorPosition().y())
                                             * info.size().x()
                                     + (info.size().x() - info.cursorPosition().x());
-                    FillConsoleOutputAttribute(console, info.attributes(), lengthToEnd, info.cursorPosition(), written);
-                    FillConsoleOutputCharacterW(console, ' ', lengthToEnd, info.cursorPosition(), written);
+                    Kernel32.FillConsoleOutputAttribute(console, info.attributes(), lengthToEnd, info.cursorPosition(), written);
+                    Kernel32.FillConsoleOutputCharacterW(console, ' ', lengthToEnd, info.cursorPosition(), written);
                     break;
                 default:
                     break;
@@ -182,26 +180,26 @@ public class WindowsAnsiProcessor extends AnsiProcessor {
             MemorySegment written = arena.allocate(ValueLayout.JAVA_INT);
             switch (eraseOption) {
                 case ERASE_LINE:
-                    COORD leftColCurrRow = info.cursorPosition().copy(arena);
+                    Kernel32.COORD leftColCurrRow = info.cursorPosition().copy(arena);
                     leftColCurrRow.x((short) 0);
-                    FillConsoleOutputAttribute(
+                    Kernel32.FillConsoleOutputAttribute(
                             console, info.attributes(), info.size().x(), leftColCurrRow, written);
-                    FillConsoleOutputCharacterW(console, ' ', info.size().x(), leftColCurrRow, written);
+                    Kernel32.FillConsoleOutputCharacterW(console, ' ', info.size().x(), leftColCurrRow, written);
                     break;
                 case ERASE_LINE_TO_BEGINING:
-                    COORD leftColCurrRow2 = info.cursorPosition().copy(arena);
+                    Kernel32.COORD leftColCurrRow2 = info.cursorPosition().copy(arena);
                     leftColCurrRow2.x((short) 0);
-                    FillConsoleOutputAttribute(
+                    Kernel32.FillConsoleOutputAttribute(
                             console, info.attributes(), info.cursorPosition().x(), leftColCurrRow2, written);
-                    FillConsoleOutputCharacterW(
+                    Kernel32.FillConsoleOutputCharacterW(
                             console, ' ', info.cursorPosition().x(), leftColCurrRow2, written);
                     break;
                 case ERASE_LINE_TO_END:
                     int lengthToLastCol =
                             info.size().x() - info.cursorPosition().x();
-                    FillConsoleOutputAttribute(
+                    Kernel32.FillConsoleOutputAttribute(
                             console, info.attributes(), lengthToLastCol, info.cursorPosition(), written);
-                    FillConsoleOutputCharacterW(console, ' ', lengthToLastCol, info.cursorPosition(), written);
+                    Kernel32.FillConsoleOutputCharacterW(console, ' ', lengthToLastCol, info.cursorPosition(), written);
                     break;
                 default:
                     break;
@@ -278,7 +276,7 @@ public class WindowsAnsiProcessor extends AnsiProcessor {
     protected void processSetForegroundColor(int color, boolean bright) throws IOException {
         info.attributes((short) ((info.attributes() & ~0x0007) | ANSI_FOREGROUND_COLOR_MAP[color]));
         if (bright) {
-            info.attributes((short) (info.attributes() | FOREGROUND_INTENSITY));
+            info.attributes((short) (info.attributes() | Kernel32.FOREGROUND_INTENSITY));
         }
         applyAttribute();
     }
@@ -299,7 +297,7 @@ public class WindowsAnsiProcessor extends AnsiProcessor {
     protected void processSetBackgroundColor(int color, boolean bright) throws IOException {
         info.attributes((short) ((info.attributes() & ~0x0070) | ANSI_BACKGROUND_COLOR_MAP[color]));
         if (bright) {
-            info.attributes((short) (info.attributes() | BACKGROUND_INTENSITY));
+            info.attributes((short) (info.attributes() | Kernel32.BACKGROUND_INTENSITY));
         }
         applyAttribute();
     }
@@ -319,14 +317,14 @@ public class WindowsAnsiProcessor extends AnsiProcessor {
     @Override
     protected void processDefaultTextColor() throws IOException {
         info.attributes((short) ((info.attributes() & ~0x000F) | (originalColors & 0xF)));
-        info.attributes((short) (info.attributes() & ~FOREGROUND_INTENSITY));
+        info.attributes((short) (info.attributes() & ~Kernel32.FOREGROUND_INTENSITY));
         applyAttribute();
     }
 
     @Override
     protected void processDefaultBackgroundColor() throws IOException {
         info.attributes((short) ((info.attributes() & ~0x00F0) | (originalColors & 0xF0)));
-        info.attributes((short) (info.attributes() & ~BACKGROUND_INTENSITY));
+        info.attributes((short) (info.attributes() & ~Kernel32.BACKGROUND_INTENSITY));
         applyAttribute();
     }
 
@@ -341,22 +339,22 @@ public class WindowsAnsiProcessor extends AnsiProcessor {
     protected void processSetAttribute(int attribute) throws IOException {
         switch (attribute) {
             case ATTRIBUTE_INTENSITY_BOLD:
-                info.attributes((short) (info.attributes() | FOREGROUND_INTENSITY));
+                info.attributes((short) (info.attributes() | Kernel32.FOREGROUND_INTENSITY));
                 applyAttribute();
                 break;
             case ATTRIBUTE_INTENSITY_NORMAL:
-                info.attributes((short) (info.attributes() & ~FOREGROUND_INTENSITY));
+                info.attributes((short) (info.attributes() & ~Kernel32.FOREGROUND_INTENSITY));
                 applyAttribute();
                 break;
 
                 // Yeah, setting the background intensity is not underlining.. but it's best we can do
                 // using the Windows console API
             case ATTRIBUTE_UNDERLINE:
-                info.attributes((short) (info.attributes() | BACKGROUND_INTENSITY));
+                info.attributes((short) (info.attributes() | Kernel32.BACKGROUND_INTENSITY));
                 applyAttribute();
                 break;
             case ATTRIBUTE_UNDERLINE_OFF:
-                info.attributes((short) (info.attributes() & ~BACKGROUND_INTENSITY));
+                info.attributes((short) (info.attributes() & ~Kernel32.BACKGROUND_INTENSITY));
                 applyAttribute();
                 break;
 
@@ -395,13 +393,13 @@ public class WindowsAnsiProcessor extends AnsiProcessor {
     protected void processInsertLine(int optionInt) throws IOException {
         getConsoleInfo();
         try (Arena arena = Arena.ofConfined()) {
-            SMALL_RECT scroll = info.window().copy(arena);
+            Kernel32.SMALL_RECT scroll = info.window().copy(arena);
             scroll.top(info.cursorPosition().y());
-            COORD org = new COORD(arena);
+            Kernel32.COORD org = new Kernel32.COORD(arena);
             org.x((short) 0);
             org.y((short) (info.cursorPosition().y() + optionInt));
-            CHAR_INFO info = new CHAR_INFO(arena, ' ', originalColors);
-            if (ScrollConsoleScreenBuffer(console, scroll, scroll, org, info) == 0) {
+            Kernel32.CHAR_INFO info = new Kernel32.CHAR_INFO(arena, ' ', originalColors);
+            if (Kernel32.ScrollConsoleScreenBuffer(console, scroll, scroll, org, info) == 0) {
                 throw new IOException(WindowsSupport.getLastErrorMessage());
             }
         }
@@ -411,13 +409,13 @@ public class WindowsAnsiProcessor extends AnsiProcessor {
     protected void processDeleteLine(int optionInt) throws IOException {
         getConsoleInfo();
         try (Arena arena = Arena.ofConfined()) {
-            SMALL_RECT scroll = info.window().copy(arena);
+            Kernel32.SMALL_RECT scroll = info.window().copy(arena);
             scroll.top(info.cursorPosition().y());
-            COORD org = new COORD(arena);
+            Kernel32.COORD org = new Kernel32.COORD(arena);
             org.x((short) 0);
             org.y((short) (info.cursorPosition().y() - optionInt));
-            CHAR_INFO info = new CHAR_INFO(arena, ' ', originalColors);
-            if (ScrollConsoleScreenBuffer(console, scroll, scroll, org, info) == 0) {
+            Kernel32.CHAR_INFO info = new Kernel32.CHAR_INFO(arena, ' ', originalColors);
+            if (Kernel32.ScrollConsoleScreenBuffer(console, scroll, scroll, org, info) == 0) {
                 throw new IOException(WindowsSupport.getLastErrorMessage());
             }
         }
@@ -429,7 +427,7 @@ public class WindowsAnsiProcessor extends AnsiProcessor {
             byte[] bytes = title.getBytes(StandardCharsets.UTF_16LE);
             MemorySegment str = arena.allocate(bytes.length + 2);
             MemorySegment.copy(bytes, 0, str, ValueLayout.JAVA_BYTE, 0, bytes.length);
-            SetConsoleTitleW(str);
+            Kernel32.SetConsoleTitleW(str);
         }
     }
 }

--- a/src/main/java/org/fusesource/jansi/internal/ffm/WindowsAnsiProcessor.java
+++ b/src/main/java/org/fusesource/jansi/internal/ffm/WindowsAnsiProcessor.java
@@ -56,25 +56,25 @@ public class WindowsAnsiProcessor extends AnsiProcessor {
     private static final short BACKGROUND_WHITE = (short) (BACKGROUND_RED | BACKGROUND_GREEN | BACKGROUND_BLUE);
 
     private static final short[] ANSI_FOREGROUND_COLOR_MAP = {
-            FOREGROUND_BLACK,
-            FOREGROUND_RED,
-            FOREGROUND_GREEN,
-            FOREGROUND_YELLOW,
-            FOREGROUND_BLUE,
-            FOREGROUND_MAGENTA,
-            FOREGROUND_CYAN,
-            FOREGROUND_WHITE,
+        FOREGROUND_BLACK,
+        FOREGROUND_RED,
+        FOREGROUND_GREEN,
+        FOREGROUND_YELLOW,
+        FOREGROUND_BLUE,
+        FOREGROUND_MAGENTA,
+        FOREGROUND_CYAN,
+        FOREGROUND_WHITE,
     };
 
     private static final short[] ANSI_BACKGROUND_COLOR_MAP = {
-            BACKGROUND_BLACK,
-            BACKGROUND_RED,
-            BACKGROUND_GREEN,
-            BACKGROUND_YELLOW,
-            BACKGROUND_BLUE,
-            BACKGROUND_MAGENTA,
-            BACKGROUND_CYAN,
-            BACKGROUND_WHITE,
+        BACKGROUND_BLACK,
+        BACKGROUND_RED,
+        BACKGROUND_GREEN,
+        BACKGROUND_YELLOW,
+        BACKGROUND_BLUE,
+        BACKGROUND_MAGENTA,
+        BACKGROUND_CYAN,
+        BACKGROUND_WHITE,
     };
 
     private final CONSOLE_SCREEN_BUFFER_INFO info = new CONSOLE_SCREEN_BUFFER_INFO(Arena.ofAuto());
@@ -156,16 +156,16 @@ public class WindowsAnsiProcessor extends AnsiProcessor {
                     topLeft2.y(info.window().top());
                     int lengthToCursor =
                             (info.cursorPosition().y() - info.window().top())
-                            * info.size().x()
-                            + info.cursorPosition().x();
+                                            * info.size().x()
+                                    + info.cursorPosition().x();
                     FillConsoleOutputAttribute(console, info.attributes(), lengthToCursor, topLeft2, written);
                     FillConsoleOutputCharacterW(console, ' ', lengthToCursor, topLeft2, written);
                     break;
                 case ERASE_SCREEN_TO_END:
                     int lengthToEnd =
                             (info.window().bottom() - info.cursorPosition().y())
-                            * info.size().x()
-                            + (info.size().x() - info.cursorPosition().x());
+                                            * info.size().x()
+                                    + (info.size().x() - info.cursorPosition().x());
                     FillConsoleOutputAttribute(console, info.attributes(), lengthToEnd, info.cursorPosition(), written);
                     FillConsoleOutputCharacterW(console, ' ', lengthToEnd, info.cursorPosition(), written);
                     break;
@@ -349,8 +349,8 @@ public class WindowsAnsiProcessor extends AnsiProcessor {
                 applyAttribute();
                 break;
 
-            // Yeah, setting the background intensity is not underlining.. but it's best we can do
-            // using the Windows console API
+                // Yeah, setting the background intensity is not underlining.. but it's best we can do
+                // using the Windows console API
             case ATTRIBUTE_UNDERLINE:
                 info.attributes((short) (info.attributes() | BACKGROUND_INTENSITY));
                 applyAttribute();

--- a/src/main/java/org/fusesource/jansi/internal/ffm/WindowsAnsiProcessor.java
+++ b/src/main/java/org/fusesource/jansi/internal/ffm/WindowsAnsiProcessor.java
@@ -45,13 +45,15 @@ public class WindowsAnsiProcessor extends AnsiProcessor {
     private static final short FOREGROUND_YELLOW = (short) (Kernel32.FOREGROUND_RED | Kernel32.FOREGROUND_GREEN);
     private static final short FOREGROUND_MAGENTA = (short) (Kernel32.FOREGROUND_BLUE | Kernel32.FOREGROUND_RED);
     private static final short FOREGROUND_CYAN = (short) (Kernel32.FOREGROUND_BLUE | Kernel32.FOREGROUND_GREEN);
-    private static final short FOREGROUND_WHITE = (short) (Kernel32.FOREGROUND_RED | Kernel32.FOREGROUND_GREEN | Kernel32.FOREGROUND_BLUE);
+    private static final short FOREGROUND_WHITE =
+            (short) (Kernel32.FOREGROUND_RED | Kernel32.FOREGROUND_GREEN | Kernel32.FOREGROUND_BLUE);
 
     private static final short BACKGROUND_BLACK = 0;
     private static final short BACKGROUND_YELLOW = (short) (Kernel32.BACKGROUND_RED | Kernel32.BACKGROUND_GREEN);
     private static final short BACKGROUND_MAGENTA = (short) (Kernel32.BACKGROUND_BLUE | Kernel32.BACKGROUND_RED);
     private static final short BACKGROUND_CYAN = (short) (Kernel32.BACKGROUND_BLUE | Kernel32.BACKGROUND_GREEN);
-    private static final short BACKGROUND_WHITE = (short) (Kernel32.BACKGROUND_RED | Kernel32.BACKGROUND_GREEN | Kernel32.BACKGROUND_BLUE);
+    private static final short BACKGROUND_WHITE =
+            (short) (Kernel32.BACKGROUND_RED | Kernel32.BACKGROUND_GREEN | Kernel32.BACKGROUND_BLUE);
 
     private static final short[] ANSI_FOREGROUND_COLOR_MAP = {
         FOREGROUND_BLACK,
@@ -164,7 +166,8 @@ public class WindowsAnsiProcessor extends AnsiProcessor {
                             (info.window().bottom() - info.cursorPosition().y())
                                             * info.size().x()
                                     + (info.size().x() - info.cursorPosition().x());
-                    Kernel32.FillConsoleOutputAttribute(console, info.attributes(), lengthToEnd, info.cursorPosition(), written);
+                    Kernel32.FillConsoleOutputAttribute(
+                            console, info.attributes(), lengthToEnd, info.cursorPosition(), written);
                     Kernel32.FillConsoleOutputCharacterW(console, ' ', lengthToEnd, info.cursorPosition(), written);
                     break;
                 default:
@@ -184,7 +187,8 @@ public class WindowsAnsiProcessor extends AnsiProcessor {
                     leftColCurrRow.x((short) 0);
                     Kernel32.FillConsoleOutputAttribute(
                             console, info.attributes(), info.size().x(), leftColCurrRow, written);
-                    Kernel32.FillConsoleOutputCharacterW(console, ' ', info.size().x(), leftColCurrRow, written);
+                    Kernel32.FillConsoleOutputCharacterW(
+                            console, ' ', info.size().x(), leftColCurrRow, written);
                     break;
                 case ERASE_LINE_TO_BEGINING:
                     Kernel32.COORD leftColCurrRow2 = info.cursorPosition().copy(arena);

--- a/src/main/java/org/fusesource/jansi/internal/ffm/WindowsCLibrary.java
+++ b/src/main/java/org/fusesource/jansi/internal/ffm/WindowsCLibrary.java
@@ -13,14 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.fusesource.jansi.ffm;
+package org.fusesource.jansi.internal.ffm;
 
 import java.lang.foreign.*;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.VarHandle;
 import java.nio.charset.StandardCharsets;
 
-import org.fusesource.jansi.AnsiConsoleSupport;
+import org.fusesource.jansi.internal.AnsiConsoleSupport;
 
 import static java.lang.foreign.ValueLayout.*;
 

--- a/src/main/java/org/fusesource/jansi/internal/jni/AnsiConsoleSupportImpl.java
+++ b/src/main/java/org/fusesource/jansi/internal/jni/AnsiConsoleSupportImpl.java
@@ -33,7 +33,7 @@ import static org.fusesource.jansi.internal.Kernel32.STD_ERROR_HANDLE;
 import static org.fusesource.jansi.internal.Kernel32.STD_OUTPUT_HANDLE;
 import static org.fusesource.jansi.internal.Kernel32.SetConsoleMode;
 
-public class AnsiConsoleSupportJni implements AnsiConsoleSupport {
+public final class AnsiConsoleSupportImpl implements AnsiConsoleSupport {
 
     @Override
     public String getProviderName() {

--- a/src/main/java/org/fusesource/jansi/internal/jni/AnsiConsoleSupportJni.java
+++ b/src/main/java/org/fusesource/jansi/internal/jni/AnsiConsoleSupportJni.java
@@ -13,13 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.fusesource.jansi.internal;
+package org.fusesource.jansi.internal.jni;
 
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 
-import org.fusesource.jansi.AnsiConsoleSupport;
+import org.fusesource.jansi.internal.AnsiConsoleSupport;
 import org.fusesource.jansi.io.AnsiProcessor;
 import org.fusesource.jansi.io.WindowsAnsiProcessor;
 

--- a/src/test/java/org/fusesource/jansi/AnsiTest.java
+++ b/src/test/java/org/fusesource/jansi/AnsiTest.java
@@ -48,11 +48,7 @@ public class AnsiTest {
 
     @Test
     public void testApply() {
-        assertEquals(
-                "test",
-                Ansi.ansi()
-                        .apply(ansi -> ansi.a("test"))
-                        .toString());
+        assertEquals("test", Ansi.ansi().apply(ansi -> ansi.a("test")).toString());
     }
 
     @ParameterizedTest


### PR DESCRIPTION
* Move the classes related to AnsiConsoleSupport to `org.fusesource.jansi.internal`;
* Using static final variables to cache `CLibrary` and `Kernel32` in `AnsiConsoleSupportHolder`;
  The purpose is to avoid duplicate creation of `CLibrary` and `Kernel32`, and make it easier to be inlined by the JIT compiler;
* Delete `JANSI_PROVIDERS_DEFAULT`,  because I think there should be a more flexible selection strategy by default rather than just relying on a list;
* Make ffm not selected by default when the jansi module does not have native access enabled;
  This prevents the JDK from printing warning messages in stderr.

