### PR TITLE
Support using FFM in native-image

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -206,20 +206,7 @@
                         <configuration>
                             <excludes>
                                 <exclude>**/ffm/*.java</exclude>
-                                <exclude>**/NativeImageFeature.java</exclude>
                             </excludes>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>jdk-9</id>
-                        <goals>
-                            <goal>compile</goal>
-                        </goals>
-                        <configuration>
-                            <release>9</release>
-                            <includes>
-                                <include>**/NativeImageFeature.java</include>
-                            </includes>
                         </configuration>
                     </execution>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,7 @@
             <groupId>org.graalvm.sdk</groupId>
             <artifactId>nativeimage</artifactId>
             <version>23.1.0</version>
+            <scope>provided</scope>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -267,6 +267,7 @@
                         <configuration>
                             <jvmVersion>9</jvmVersion>
                             <module>
+                                <mainClass>org.fusesource.jansi.AnsiMain</mainClass>
                                 <moduleInfo>
                                     <name>org.fusesource.jansi</name>
                                     <exports>org.fusesource.jansi;

--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,12 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.graalvm.sdk</groupId>
+            <artifactId>nativeimage</artifactId>
+            <version>23.1.0</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>5.7.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -206,7 +206,20 @@
                         <configuration>
                             <excludes>
                                 <exclude>**/ffm/*.java</exclude>
+                                <exclude>**/NativeImageFeature.java</exclude>
                             </excludes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>jdk-9</id>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <release>9</release>
+                            <includes>
+                                <include>**/NativeImageFeature.java</include>
+                            </includes>
                         </configuration>
                     </execution>
                     <execution>

--- a/src/main/java/org/fusesource/jansi/internal/AnsiConsoleSupportHolder.java
+++ b/src/main/java/org/fusesource/jansi/internal/AnsiConsoleSupportHolder.java
@@ -32,6 +32,7 @@ public final class AnsiConsoleSupportHolder {
                     .getConstructor(boolean.class)
                     .newInstance(true);
         } catch (Throwable ignored) {
+            ignored.printStackTrace();
         }
 
         return new org.fusesource.jansi.internal.jni.AnsiConsoleSupportImpl();

--- a/src/main/java/org/fusesource/jansi/internal/AnsiConsoleSupportHolder.java
+++ b/src/main/java/org/fusesource/jansi/internal/AnsiConsoleSupportHolder.java
@@ -25,14 +25,16 @@ public final class AnsiConsoleSupportHolder {
     private static final Throwable ERR;
 
     private static AnsiConsoleSupport getDefaultProvider() {
-        try {
-            // Call the specialized constructor to check whether the module has native access enabled
-            // If not, fallback to JNI to avoid the JDK printing warnings in stderr
-            return (AnsiConsoleSupport) Class.forName("org.fusesource.jansi.internal.ffm.AnsiConsoleSupportImpl")
-                    .getConstructor(boolean.class)
-                    .newInstance(true);
-        } catch (Throwable ignored) {
-            ignored.printStackTrace(); // TODO: for debug, should be deleted before merging
+        if (!OSInfo.isInImageCode()) {
+            try {
+                // Call the specialized constructor to check whether the module has native access enabled
+                // If not, fallback to JNI to avoid the JDK printing warnings in stderr
+                return (AnsiConsoleSupport) Class.forName("org.fusesource.jansi.internal.ffm.AnsiConsoleSupportImpl")
+                        .getConstructor(boolean.class)
+                        .newInstance(true);
+            } catch (Throwable ignored) {
+                ignored.printStackTrace(); // TODO: for debug, should be deleted before merging
+            }
         }
 
         return new org.fusesource.jansi.internal.jni.AnsiConsoleSupportImpl();

--- a/src/main/java/org/fusesource/jansi/internal/AnsiConsoleSupportHolder.java
+++ b/src/main/java/org/fusesource/jansi/internal/AnsiConsoleSupportHolder.java
@@ -32,7 +32,6 @@ public final class AnsiConsoleSupportHolder {
                         .getConstructor(boolean.class)
                         .newInstance(true);
             } catch (Throwable ignored) {
-                ignored.printStackTrace(); // TODO: for debug, should be deleted before merging
             }
         }
 

--- a/src/main/java/org/fusesource/jansi/internal/AnsiConsoleSupportHolder.java
+++ b/src/main/java/org/fusesource/jansi/internal/AnsiConsoleSupportHolder.java
@@ -86,54 +86,22 @@ public final class AnsiConsoleSupportHolder {
         ERR = err;
     }
 
-    public static String getProviderName() {
-        return PROVIDER.getProviderName();
+    public static AnsiConsoleSupport getProvider() {
+        if (PROVIDER == null) {
+            throw new RuntimeException("No provider available", ERR);
+        }
+        return PROVIDER;
     }
 
-    private static final class LibraryHolder {
-        static final AnsiConsoleSupport.CLibrary CLIBRARY;
-        static final AnsiConsoleSupport.Kernel32 KERNEL32;
-        static final Throwable ERR;
-
-        static {
-            AnsiConsoleSupport.CLibrary clib = null;
-            AnsiConsoleSupport.Kernel32 kernel32 = null;
-            Throwable err = null;
-
-            if (PROVIDER != null) {
-                try {
-                    clib = PROVIDER.getCLibrary();
-                    kernel32 = OSInfo.isWindows() ? PROVIDER.getKernel32() : null;
-                } catch (Throwable e) {
-                    err = e;
-                }
-            } else {
-                err = AnsiConsoleSupportHolder.ERR;
-            }
-
-            CLIBRARY = clib;
-            KERNEL32 = kernel32;
-            ERR = err;
-        }
+    public static String getProviderName() {
+        return getProvider().getProviderName();
     }
 
     public static AnsiConsoleSupport.CLibrary getCLibrary() {
-        if (LibraryHolder.CLIBRARY == null) {
-            throw new RuntimeException("Unable to get the instance of CLibrary", LibraryHolder.ERR);
-        }
-
-        return LibraryHolder.CLIBRARY;
+        return getProvider().getCLibrary();
     }
 
     public static AnsiConsoleSupport.Kernel32 getKernel32() {
-        if (LibraryHolder.KERNEL32 == null) {
-            if (OSInfo.isWindows()) {
-                throw new RuntimeException("Unable to get the instance of Kernel32", ERR);
-            } else {
-                throw new UnsupportedOperationException("Not Windows");
-            }
-        }
-
-        return LibraryHolder.KERNEL32;
+        return getProvider().getKernel32();
     }
 }

--- a/src/main/java/org/fusesource/jansi/internal/AnsiConsoleSupportHolder.java
+++ b/src/main/java/org/fusesource/jansi/internal/AnsiConsoleSupportHolder.java
@@ -32,7 +32,7 @@ public final class AnsiConsoleSupportHolder {
                     .getConstructor(boolean.class)
                     .newInstance(true);
         } catch (Throwable ignored) {
-            ignored.printStackTrace();
+            ignored.printStackTrace(); // TODO: for debug, should be deleted before merging
         }
 
         return new org.fusesource.jansi.internal.jni.AnsiConsoleSupportImpl();

--- a/src/main/java/org/fusesource/jansi/internal/NativeImageFeature.java
+++ b/src/main/java/org/fusesource/jansi/internal/NativeImageFeature.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2009-2023 the original author(s).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fusesource.jansi.internal;
+
+import org.fusesource.jansi.AnsiConsole;
+import org.graalvm.nativeimage.hosted.Feature;
+import org.graalvm.nativeimage.hosted.RuntimeResourceAccess;
+
+public class NativeImageFeature implements Feature {
+    @Override
+    public String getURL() {
+        return "https://github.com/fusesource/jansi";
+    }
+
+    @Override
+    public void duringSetup(DuringSetupAccess access) {
+        String providers = System.getProperty(AnsiConsole.JANSI_PROVIDERS);
+        if (providers != null && providers.contains("ffm")) {
+            try {
+                // FFM is only available in JDK 21+, so we need to compile it separately
+                Class.forName("org.fusesource.jansi.internal.ffm.NativeImageDowncallRegister")
+                        .getMethod("registerForDowncall")
+                        .invoke(null);
+            } catch (Throwable e) {
+                throw new RuntimeException(e);
+            }
+        } else {
+            String jansiNativeLibraryName = System.mapLibraryName("jansi");
+            if (jansiNativeLibraryName.endsWith(".dylib")) {
+                jansiNativeLibraryName = jansiNativeLibraryName.replace(".dylib", ".jnilib");
+            }
+
+            String packagePath = JansiLoader.class.getPackage().getName().replace('.', '/');
+            RuntimeResourceAccess.addResource(
+                    JansiLoader.class.getModule(),
+                    String.format(
+                            "/%s/native/%s/%s",
+                            packagePath, OSInfo.getNativeLibFolderPathForCurrentOS(), jansiNativeLibraryName));
+        }
+    }
+}

--- a/src/main/java/org/fusesource/jansi/internal/NativeImageFeature.java
+++ b/src/main/java/org/fusesource/jansi/internal/NativeImageFeature.java
@@ -47,7 +47,7 @@ public class NativeImageFeature implements Feature {
             RuntimeResourceAccess.addResource(
                     JansiLoader.class.getModule(),
                     String.format(
-                            "/%s/native/%s/%s",
+                            "%s/native/%s/%s",
                             packagePath, OSInfo.getNativeLibFolderPathForCurrentOS(), jansiNativeLibraryName));
         }
     }

--- a/src/main/java/org/fusesource/jansi/internal/NativeImageFeature.java
+++ b/src/main/java/org/fusesource/jansi/internal/NativeImageFeature.java
@@ -29,7 +29,6 @@ public class NativeImageFeature implements Feature {
     @Override
     public void duringSetup(DuringSetupAccess access) {
         RuntimeClassInitialization.initializeAtBuildTime(AnsiConsoleSupportHolder.class);
-        RuntimeClassInitialization.initializeAtBuildTime(OSInfo.class);
 
         String providers = System.getProperty(AnsiConsole.JANSI_PROVIDERS);
         if (providers != null) {

--- a/src/main/java/org/fusesource/jansi/internal/NativeImageFeature.java
+++ b/src/main/java/org/fusesource/jansi/internal/NativeImageFeature.java
@@ -28,7 +28,7 @@ public class NativeImageFeature implements Feature {
     @Override
     public void duringSetup(DuringSetupAccess access) {
         String providers = System.getProperty(AnsiConsole.JANSI_PROVIDERS);
-        if (providers != null && providers.contains("ffm")) {
+        if (providers != null && providers.contains(AnsiConsole.JANSI_PROVIDER_FFM)) {
             try {
                 // FFM is only available in JDK 21+, so we need to compile it separately
                 Class.forName("org.fusesource.jansi.internal.ffm.NativeImageDowncallRegister")
@@ -37,7 +37,9 @@ public class NativeImageFeature implements Feature {
             } catch (Throwable e) {
                 throw new RuntimeException(e);
             }
-        } else {
+        }
+
+        if (providers == null || providers.contains(AnsiConsole.JANSI_PROVIDER_JNI)){
             String jansiNativeLibraryName = System.mapLibraryName("jansi");
             if (jansiNativeLibraryName.endsWith(".dylib")) {
                 jansiNativeLibraryName = jansiNativeLibraryName.replace(".dylib", ".jnilib");

--- a/src/main/java/org/fusesource/jansi/internal/NativeImageFeature.java
+++ b/src/main/java/org/fusesource/jansi/internal/NativeImageFeature.java
@@ -39,7 +39,7 @@ public class NativeImageFeature implements Feature {
             }
         }
 
-        if (providers == null || providers.contains(AnsiConsole.JANSI_PROVIDER_JNI)){
+        if (providers == null || providers.contains(AnsiConsole.JANSI_PROVIDER_JNI)) {
             String jansiNativeLibraryName = System.mapLibraryName("jansi");
             if (jansiNativeLibraryName.endsWith(".dylib")) {
                 jansiNativeLibraryName = jansiNativeLibraryName.replace(".dylib", ".jnilib");

--- a/src/main/java/org/fusesource/jansi/internal/NativeImageFeature.java
+++ b/src/main/java/org/fusesource/jansi/internal/NativeImageFeature.java
@@ -17,7 +17,9 @@ package org.fusesource.jansi.internal;
 
 import org.fusesource.jansi.AnsiConsole;
 import org.graalvm.nativeimage.hosted.Feature;
+import org.graalvm.nativeimage.hosted.RuntimeClassInitialization;
 import org.graalvm.nativeimage.hosted.RuntimeResourceAccess;
+import org.graalvm.nativeimage.hosted.RuntimeSystemProperties;
 
 public class NativeImageFeature implements Feature {
     @Override
@@ -28,6 +30,10 @@ public class NativeImageFeature implements Feature {
     @Override
     public void duringSetup(DuringSetupAccess access) {
         String providers = System.getProperty(AnsiConsole.JANSI_PROVIDERS);
+        if (providers != null) {
+            RuntimeSystemProperties.register(AnsiConsole.JANSI_PROVIDERS, providers);
+        }
+
         if (providers != null && providers.contains(AnsiConsole.JANSI_PROVIDER_FFM)) {
             try {
                 // FFM is only available in JDK 21+, so we need to compile it separately
@@ -52,5 +58,7 @@ public class NativeImageFeature implements Feature {
                             "%s/native/%s/%s",
                             packagePath, OSInfo.getNativeLibFolderPathForCurrentOS(), jansiNativeLibraryName));
         }
+
+        RuntimeClassInitialization.initializeAtBuildTime(AnsiConsoleSupportHolder.class);
     }
 }

--- a/src/main/java/org/fusesource/jansi/internal/NativeImageFeature.java
+++ b/src/main/java/org/fusesource/jansi/internal/NativeImageFeature.java
@@ -15,6 +15,8 @@
  */
 package org.fusesource.jansi.internal;
 
+import java.util.Objects;
+
 import org.fusesource.jansi.AnsiConsole;
 import org.graalvm.nativeimage.hosted.Feature;
 import org.graalvm.nativeimage.hosted.RuntimeClassInitialization;
@@ -40,9 +42,8 @@ public class NativeImageFeature implements Feature {
             }
         }
 
-        String provider = AnsiConsoleSupportHolder.getProviderName();
-
-        if (provider == null || provider.equals(AnsiConsole.JANSI_PROVIDER_JNI)) {
+        String provider = Objects.requireNonNull(AnsiConsoleSupportHolder.getProviderName(), "No provider available");
+        if (provider.equals(AnsiConsole.JANSI_PROVIDER_JNI)) {
             String jansiNativeLibraryName = System.mapLibraryName("jansi");
             if (jansiNativeLibraryName.endsWith(".dylib")) {
                 jansiNativeLibraryName = jansiNativeLibraryName.replace(".dylib", ".jnilib");

--- a/src/main/java/org/fusesource/jansi/internal/NativeImageFeature.java
+++ b/src/main/java/org/fusesource/jansi/internal/NativeImageFeature.java
@@ -34,6 +34,7 @@ public class NativeImageFeature implements Feature {
                 RuntimeSystemProperties.register(AnsiConsole.JANSI_PROVIDERS, providers);
             } catch (Throwable ignored) {
                 // GraalVM version < 23.0
+                // No need to worry as we select the provider at build time
             }
         }
 
@@ -73,6 +74,7 @@ public class NativeImageFeature implements Feature {
 
             } catch (Throwable ignored) {
                 // GraalVM version < 22.3
+                // Users need to manually add the JNI library as resources
             }
         }
 

--- a/src/main/java/org/fusesource/jansi/internal/OSInfo.java
+++ b/src/main/java/org/fusesource/jansi/internal/OSInfo.java
@@ -182,7 +182,7 @@ public class OSInfo {
         while ((readLen = in.read(buf, 0, buf.length)) >= 0) {
             b.write(buf, 0, readLen);
         }
-        return b.toString();
+        return b.toString("UTF-8");
     }
 
     static String resolveArmArchType() {

--- a/src/main/java/org/fusesource/jansi/internal/OSInfo.java
+++ b/src/main/java/org/fusesource/jansi/internal/OSInfo.java
@@ -66,7 +66,7 @@ public class OSInfo {
         System.out.print(getNativeLibFolderPathForCurrentOS());
     }
 
-    private static String mapArch(String arch) {
+    private static String mapArchName(String arch) {
         switch (arch.toLowerCase(Locale.ROOT)) {
                 // x86 mappings
             case X86:
@@ -224,7 +224,7 @@ public class OSInfo {
         if (osArch.startsWith("arm")) {
             osArch = resolveArmArchType();
         } else {
-            String arch = mapArch(osArch);
+            String arch = mapArchName(osArch);
             if (arch != null) {
                 return arch;
             }

--- a/src/main/java/org/fusesource/jansi/internal/OSInfo.java
+++ b/src/main/java/org/fusesource/jansi/internal/OSInfo.java
@@ -36,12 +36,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.HashMap;
 import java.util.Locale;
 
 /**
  * Provides OS name and architecture name.
- *
  */
 public class OSInfo {
 
@@ -53,52 +51,6 @@ public class OSInfo {
     public static final String PPC64 = "ppc64";
     public static final String ARM64 = "arm64";
     public static final String RISCV64 = "riscv64";
-
-    private static final HashMap<String, String> archMapping = new HashMap<String, String>();
-
-    static {
-        // x86 mappings
-        archMapping.put(X86, X86);
-        archMapping.put("i386", X86);
-        archMapping.put("i486", X86);
-        archMapping.put("i586", X86);
-        archMapping.put("i686", X86);
-        archMapping.put("pentium", X86);
-
-        // x86_64 mappings
-        archMapping.put(X86_64, X86_64);
-        archMapping.put("amd64", X86_64);
-        archMapping.put("em64t", X86_64);
-        archMapping.put("universal", X86_64); // Needed for openjdk7 in Mac
-
-        // Itenium 64-bit mappings
-        archMapping.put(IA64, IA64);
-        archMapping.put("ia64w", IA64);
-
-        // Itenium 32-bit mappings, usually an HP-UX construct
-        archMapping.put(IA64_32, IA64_32);
-        archMapping.put("ia64n", IA64_32);
-
-        // PowerPC mappings
-        archMapping.put(PPC, PPC);
-        archMapping.put("power", PPC);
-        archMapping.put("powerpc", PPC);
-        archMapping.put("power_pc", PPC);
-        archMapping.put("power_rs", PPC);
-
-        // TODO: PowerPC 64bit mappings
-        archMapping.put(PPC64, PPC64);
-        archMapping.put("power64", PPC64);
-        archMapping.put("powerpc64", PPC64);
-        archMapping.put("power_pc64", PPC64);
-        archMapping.put("power_rs64", PPC64);
-
-        // aarch64 mappings
-        archMapping.put("aarch64", ARM64);
-
-        // riscv64 mappings
-        archMapping.put(RISCV64, RISCV64);
-    }
 
     public static void main(String[] args) {
         if (args.length >= 1) {
@@ -112,6 +64,63 @@ public class OSInfo {
         }
 
         System.out.print(getNativeLibFolderPathForCurrentOS());
+    }
+
+    private static String mapArch(String arch) {
+        switch (arch.toLowerCase(Locale.ROOT)) {
+                // x86 mappings
+            case X86:
+            case "i386":
+            case "i486":
+            case "i586":
+            case "i686":
+            case "pentium":
+                return X86;
+
+                // x86_64 mappings
+            case X86_64:
+            case "amd64":
+            case "em64t":
+            case "universal": // Needed for openjdk7 in Mac
+                return X86_64;
+
+                // Itenium 64-bit mappings
+            case IA64:
+            case "ia64w":
+                return IA64;
+
+                // Itenium 32-bit mappings, usually an HP-UX construct
+            case IA64_32:
+            case "ia64n":
+                return IA64_32;
+
+                // PowerPC mappings
+            case PPC:
+            case "power":
+            case "powerpc":
+            case "power_pc":
+            case "power_rs":
+                return PPC;
+
+                // TODO: PowerPC 64bit mappings
+            case PPC64:
+            case "power64":
+            case "powerpc64":
+            case "power_pc64":
+            case "power_rs64":
+                return PPC64;
+
+                // aarch64 mappings
+            case "aarch64":
+                return ARM64;
+
+                // riscv64 mappings
+            case RISCV64:
+                return RISCV64;
+
+            default:
+                return null;
+        }
     }
 
     public static String getNativeLibFolderPathForCurrentOS() {
@@ -143,6 +152,10 @@ public class OSInfo {
         }
 
         return false;
+    }
+
+    public static boolean isInImageCode() {
+        return System.getProperty("org.graalvm.nativeimage.imagecode") != null;
     }
 
     static String getHardwareName() {
@@ -211,8 +224,10 @@ public class OSInfo {
         if (osArch.startsWith("arm")) {
             osArch = resolveArmArchType();
         } else {
-            String lc = osArch.toLowerCase(Locale.ROOT);
-            if (archMapping.containsKey(lc)) return archMapping.get(lc);
+            String arch = mapArch(osArch);
+            if (arch != null) {
+                return arch;
+            }
         }
         return translateArchNameToFolderName(osArch);
     }

--- a/src/main/java/org/fusesource/jansi/internal/ffm/AnsiConsoleSupportImpl.java
+++ b/src/main/java/org/fusesource/jansi/internal/ffm/AnsiConsoleSupportImpl.java
@@ -27,11 +27,14 @@ import org.fusesource.jansi.io.AnsiProcessor;
 
 import static org.fusesource.jansi.internal.ffm.Kernel32.*;
 
-public final class AnsiConsoleSupportImpl implements AnsiConsoleSupport {
+public final class AnsiConsoleSupportImpl extends AnsiConsoleSupport {
 
-    public AnsiConsoleSupportImpl() {}
+    public AnsiConsoleSupportImpl() {
+        super("ffm");
+    }
 
     public AnsiConsoleSupportImpl(boolean checkNativeAccess) {
+        this();
         if (checkNativeAccess && !AnsiConsoleSupportImpl.class.getModule().isNativeAccessEnabled()) {
             throw new UnsupportedOperationException(
                     "Native access is not enabled for the current module: " + AnsiConsoleSupportImpl.class.getModule());
@@ -39,12 +42,7 @@ public final class AnsiConsoleSupportImpl implements AnsiConsoleSupport {
     }
 
     @Override
-    public String getProviderName() {
-        return "ffm";
-    }
-
-    @Override
-    public CLibrary getCLibrary() {
+    protected CLibrary createCLibrary() {
         if (OSInfo.isWindows()) {
             return new WindowsCLibrary();
         } else {
@@ -53,7 +51,7 @@ public final class AnsiConsoleSupportImpl implements AnsiConsoleSupport {
     }
 
     @Override
-    public Kernel32 getKernel32() {
+    protected Kernel32 createKernel32() {
         return new Kernel32() {
             @Override
             public int isTty(long console) {

--- a/src/main/java/org/fusesource/jansi/internal/ffm/AnsiConsoleSupportImpl.java
+++ b/src/main/java/org/fusesource/jansi/internal/ffm/AnsiConsoleSupportImpl.java
@@ -33,7 +33,8 @@ public final class AnsiConsoleSupportImpl implements AnsiConsoleSupport {
 
     public AnsiConsoleSupportImpl(boolean checkNativeAccess) {
         if (checkNativeAccess && !AnsiConsoleSupportImpl.class.getModule().isNativeAccessEnabled()) {
-            throw new UnsupportedOperationException("Native access is not enabled for the current module");
+            throw new UnsupportedOperationException(
+                    "Native access is not enabled for the current module: " + AnsiConsoleSupportImpl.class.getModule());
         }
     }
 

--- a/src/main/java/org/fusesource/jansi/internal/ffm/Kernel32.java
+++ b/src/main/java/org/fusesource/jansi/internal/ffm/Kernel32.java
@@ -244,7 +244,7 @@ final class Kernel32 {
             SMALL_RECT lpClipRectangle,
             COORD dwDestinationOrigin,
             CHAR_INFO lpFill) {
-        MethodHandle mh$ = requireNonNull(ScrollConsoleScreenBuffer$MH, "ScrollConsoleScreenBuffer");
+        MethodHandle mh$ = requireNonNull(ScrollConsoleScreenBufferW$MH, "ScrollConsoleScreenBuffer");
         try {
             return (int)
                     mh$.invokeExact(hConsoleOutput, lpScrollRectangle, lpClipRectangle, dwDestinationOrigin, lpFill);
@@ -318,8 +318,9 @@ final class Kernel32 {
     private static final SymbolLookup SYMBOL_LOOKUP;
 
     static {
+        System.loadLibrary("msvcrt");
         System.loadLibrary("Kernel32");
-        SYMBOL_LOOKUP = SymbolLookup.loaderLookup().or(Linker.nativeLinker().defaultLookup());
+        SYMBOL_LOOKUP = SymbolLookup.loaderLookup();
     }
 
     static MethodHandle downcallHandle(String name, FunctionDescriptor fdesc) {
@@ -396,8 +397,8 @@ final class Kernel32 {
     static final MethodHandle GetConsoleScreenBufferInfo$MH = downcallHandle(
             "GetConsoleScreenBufferInfo", FunctionDescriptor.of(C_INT$LAYOUT, C_POINTER$LAYOUT, C_POINTER$LAYOUT));
 
-    static final MethodHandle ScrollConsoleScreenBuffer$MH = downcallHandle(
-            "ScrollConsoleScreenBuffer",
+    static final MethodHandle ScrollConsoleScreenBufferW$MH = downcallHandle(
+            "ScrollConsoleScreenBufferW",
             FunctionDescriptor.of(
                     C_INT$LAYOUT,
                     C_POINTER$LAYOUT,

--- a/src/main/java/org/fusesource/jansi/internal/ffm/NativeImageDowncallRegister.java
+++ b/src/main/java/org/fusesource/jansi/internal/ffm/NativeImageDowncallRegister.java
@@ -15,22 +15,24 @@
  */
 package org.fusesource.jansi.internal.ffm;
 
-import java.lang.foreign.*;
+import java.lang.foreign.AddressLayout;
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.StructLayout;
+import java.lang.foreign.ValueLayout;
 
 import org.graalvm.nativeimage.Platform;
-import org.graalvm.nativeimage.hosted.Feature;
 import org.graalvm.nativeimage.hosted.RuntimeForeignAccess;
 
 import static java.lang.foreign.ValueLayout.*;
 
-public final class NativeImageFeatures implements Feature {
+public final class NativeImageDowncallRegister {
 
     private static void registerForDowncall(MemoryLayout resLayout, MemoryLayout... argLayouts) {
         RuntimeForeignAccess.registerForDowncall(FunctionDescriptor.of(resLayout, argLayouts));
     }
 
-    @Override
-    public void duringSetup(DuringSetupAccess access) {
+    public static void registerForDowncall() {
         if (Platform.includedIn(Platform.WINDOWS.class)) {
             final OfShort C_SHORT$LAYOUT = JAVA_SHORT;
             final OfInt C_INT$LAYOUT = JAVA_INT;

--- a/src/main/java/org/fusesource/jansi/internal/ffm/NativeImageFeatures.java
+++ b/src/main/java/org/fusesource/jansi/internal/ffm/NativeImageFeatures.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2009-2023 the original author(s).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fusesource.jansi.internal.ffm;
+
+import java.lang.foreign.*;
+
+import org.graalvm.nativeimage.Platform;
+import org.graalvm.nativeimage.hosted.Feature;
+import org.graalvm.nativeimage.hosted.RuntimeForeignAccess;
+
+import static java.lang.foreign.ValueLayout.*;
+
+public final class NativeImageFeatures implements Feature {
+
+    private static void registerForDowncall(MemoryLayout resLayout, MemoryLayout... argLayouts) {
+        RuntimeForeignAccess.registerForDowncall(FunctionDescriptor.of(resLayout, argLayouts));
+    }
+
+    @Override
+    public void duringSetup(DuringSetupAccess access) {
+        if (Platform.includedIn(Platform.WINDOWS.class)) {
+            final OfShort C_SHORT$LAYOUT = JAVA_SHORT;
+            final OfInt C_INT$LAYOUT = JAVA_INT;
+            final AddressLayout C_POINTER$LAYOUT = ADDRESS;
+
+            StructLayout COORD$LAYOUT =
+                    MemoryLayout.structLayout(C_SHORT$LAYOUT.withName("x"), C_SHORT$LAYOUT.withName("y"));
+
+            // WaitForSingleObject
+            registerForDowncall(C_INT$LAYOUT, C_POINTER$LAYOUT, C_INT$LAYOUT);
+            // GetStdHandle
+            registerForDowncall(C_POINTER$LAYOUT, C_INT$LAYOUT);
+            // FormatMessageW
+            registerForDowncall(
+                    C_INT$LAYOUT,
+                    C_INT$LAYOUT,
+                    C_POINTER$LAYOUT,
+                    C_INT$LAYOUT,
+                    C_INT$LAYOUT,
+                    C_POINTER$LAYOUT,
+                    C_INT$LAYOUT,
+                    C_POINTER$LAYOUT);
+            // SetConsoleTextAttribute
+            registerForDowncall(C_INT$LAYOUT, C_POINTER$LAYOUT, C_SHORT$LAYOUT);
+            // SetConsoleMode
+            registerForDowncall(C_INT$LAYOUT, C_POINTER$LAYOUT, C_INT$LAYOUT);
+            // GetConsoleMode
+            registerForDowncall(C_INT$LAYOUT, C_POINTER$LAYOUT, C_POINTER$LAYOUT);
+            // SetConsoleTitleW
+            registerForDowncall(C_INT$LAYOUT, C_POINTER$LAYOUT);
+            // SetConsoleCursorPosition
+            registerForDowncall(C_INT$LAYOUT, C_POINTER$LAYOUT, COORD$LAYOUT);
+            // FillConsoleOutputCharacterW
+            registerForDowncall(
+                    C_INT$LAYOUT, C_POINTER$LAYOUT, C_SHORT$LAYOUT, C_INT$LAYOUT, COORD$LAYOUT, C_POINTER$LAYOUT);
+            // FillConsoleOutputAttribute
+            registerForDowncall(
+                    C_INT$LAYOUT, C_POINTER$LAYOUT, C_SHORT$LAYOUT, C_INT$LAYOUT, COORD$LAYOUT, C_POINTER$LAYOUT);
+            // WriteConsoleW
+            registerForDowncall(
+                    C_INT$LAYOUT, C_POINTER$LAYOUT, C_POINTER$LAYOUT, C_INT$LAYOUT, C_POINTER$LAYOUT, C_POINTER$LAYOUT);
+            // ReadConsoleInputW
+            registerForDowncall(C_INT$LAYOUT, C_POINTER$LAYOUT, C_POINTER$LAYOUT, C_INT$LAYOUT, C_POINTER$LAYOUT);
+            // PeekConsoleInputW
+            registerForDowncall(C_INT$LAYOUT, C_POINTER$LAYOUT, C_POINTER$LAYOUT, C_INT$LAYOUT, C_POINTER$LAYOUT);
+            // GetConsoleScreenBufferInfo
+            registerForDowncall(C_INT$LAYOUT, C_POINTER$LAYOUT, C_POINTER$LAYOUT);
+            // ScrollConsoleScreenBuffer
+            registerForDowncall(
+                    C_INT$LAYOUT, C_POINTER$LAYOUT, C_POINTER$LAYOUT, C_POINTER$LAYOUT, COORD$LAYOUT, C_POINTER$LAYOUT);
+            // GetLastError
+            registerForDowncall(C_INT$LAYOUT);
+            // GetFileType
+            registerForDowncall(C_INT$LAYOUT, C_POINTER$LAYOUT);
+            // _get_osfhandle
+            registerForDowncall(C_POINTER$LAYOUT, C_INT$LAYOUT);
+            // NtQueryObject
+            registerForDowncall(JAVA_INT, ADDRESS, JAVA_INT, ADDRESS, JAVA_LONG, ADDRESS);
+        } else if (Platform.includedIn(Platform.LINUX.class) || Platform.includedIn(Platform.DARWIN.class)) {
+            // ioctl
+            registerForDowncall(ValueLayout.JAVA_INT, ValueLayout.JAVA_INT, ValueLayout.JAVA_LONG, ValueLayout.ADDRESS);
+            // isatty
+            registerForDowncall(ValueLayout.JAVA_INT, ValueLayout.JAVA_INT);
+        } else {
+            throw new UnsupportedOperationException("Unsupported platform");
+        }
+    }
+}

--- a/src/main/java/org/fusesource/jansi/internal/ffm/PosixCLibrary.java
+++ b/src/main/java/org/fusesource/jansi/internal/ffm/PosixCLibrary.java
@@ -52,14 +52,20 @@ final class PosixCLibrary implements AnsiConsoleSupport.CLibrary {
                 ValueLayout.JAVA_SHORT);
         ws_col = wsLayout.varHandle(MemoryLayout.PathElement.groupElement("ws_col"));
         Linker linker = Linker.nativeLinker();
+        SymbolLookup lookup;
+        if (System.getProperty("org.graalvm.nativeimage.imagecode") != null) {
+            lookup = SymbolLookup.loaderLookup();
+        } else {
+            lookup = linker.defaultLookup();
+        }
+
         ioctl = linker.downcallHandle(
-                linker.defaultLookup().find("ioctl").get(),
+                lookup.find("ioctl").get(),
                 FunctionDescriptor.of(
                         ValueLayout.JAVA_INT, ValueLayout.JAVA_INT, ValueLayout.JAVA_LONG, ValueLayout.ADDRESS),
                 Linker.Option.firstVariadicArg(2));
         isatty = linker.downcallHandle(
-                linker.defaultLookup().find("isatty").get(),
-                FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.JAVA_INT));
+                lookup.find("isatty").get(), FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.JAVA_INT));
     }
 
     @Override

--- a/src/main/java/org/fusesource/jansi/internal/ffm/PosixCLibrary.java
+++ b/src/main/java/org/fusesource/jansi/internal/ffm/PosixCLibrary.java
@@ -20,6 +20,7 @@ import java.lang.invoke.MethodHandle;
 import java.lang.invoke.VarHandle;
 
 import org.fusesource.jansi.internal.AnsiConsoleSupport;
+import org.fusesource.jansi.internal.OSInfo;
 
 final class PosixCLibrary implements AnsiConsoleSupport.CLibrary {
     private static final int TIOCGWINSZ;
@@ -53,7 +54,7 @@ final class PosixCLibrary implements AnsiConsoleSupport.CLibrary {
         ws_col = wsLayout.varHandle(MemoryLayout.PathElement.groupElement("ws_col"));
         Linker linker = Linker.nativeLinker();
         SymbolLookup lookup;
-        if (System.getProperty("org.graalvm.nativeimage.imagecode") != null) {
+        if (OSInfo.isInImageCode()) {
             lookup = SymbolLookup.loaderLookup();
         } else {
             lookup = linker.defaultLookup();

--- a/src/main/java/org/fusesource/jansi/internal/jni/AnsiConsoleSupportImpl.java
+++ b/src/main/java/org/fusesource/jansi/internal/jni/AnsiConsoleSupportImpl.java
@@ -33,15 +33,14 @@ import static org.fusesource.jansi.internal.Kernel32.STD_ERROR_HANDLE;
 import static org.fusesource.jansi.internal.Kernel32.STD_OUTPUT_HANDLE;
 import static org.fusesource.jansi.internal.Kernel32.SetConsoleMode;
 
-public final class AnsiConsoleSupportImpl implements AnsiConsoleSupport {
+public final class AnsiConsoleSupportImpl extends AnsiConsoleSupport {
 
-    @Override
-    public String getProviderName() {
-        return "jni";
+    public AnsiConsoleSupportImpl() {
+        super("jni");
     }
 
     @Override
-    public CLibrary getCLibrary() {
+    protected CLibrary createCLibrary() {
         return new CLibrary() {
             @Override
             public short getTerminalWidth(int fd) {
@@ -56,7 +55,7 @@ public final class AnsiConsoleSupportImpl implements AnsiConsoleSupport {
     }
 
     @Override
-    public Kernel32 getKernel32() {
+    protected Kernel32 createKernel32() {
         return new Kernel32() {
             @Override
             public int isTty(long console) {

--- a/src/main/resources/META-INF/native-image/jansi/native-image.properties
+++ b/src/main/resources/META-INF/native-image/jansi/native-image.properties
@@ -1,0 +1,1 @@
+Args=--features=org.fusesource.jansi.internal.NativeImageFeature

--- a/src/main/resources/META-INF/native-image/jansi/resource-config.json
+++ b/src/main/resources/META-INF/native-image/jansi/resource-config.json
@@ -1,7 +1,6 @@
 {
   "resources": [
     {"pattern": "org/fusesource/jansi/jansi.properties"},
-    {"pattern": "org/fusesource/jansi/jansi.txt"},
-    {"pattern": "org/fusesource/jansi/internal/native/.*"}
+    {"pattern": "org/fusesource/jansi/jansi.txt"}
   ]
 }


### PR DESCRIPTION
See: https://www.graalvm.org/latest/reference-manual/native-image/dynamic-features/foreign-interface/

This PR provides FFM support for native-image.

Since FFM support in both JDK 21 and GraalVM is in preview, this PR is also experimental until GraalVM provides stable support for FFM.

Users need to provide the following options to the native-image tool to enable FFM support: 

```
--enable-preview --enable-native-access=org.fusesource.jansi -Djansi.providers=ffm
```

If jansi is on the class path instead of the module path, replace `org.fusesource.jansi` with `ALL-UNNAMED`.

This PR is working, but there seems to be some glitch that I still need to look into

