### PR TITLE
Fix building on Windows with JDJ 24

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -261,6 +261,7 @@
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     <forkCount>1</forkCount>
                     <reuseForks>true</reuseForks>
+                    <argLine>--enable-native-access=ALL-UNNAMED</argLine>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
The error was during running tests
```
[ERROR] WARNING: A restricted method in java.lang.System has been called
[ERROR] WARNING: java.lang.System::load has been called by org.fusesource.jansi.internal.JansiLoader in an unnamed module
```