### PR TITLE
Fix buffer comparison in JansiLoader.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,8 +101,9 @@
     </distributionManagement>
 
     <properties>
-        <javadocSource>8</javadocSource>
-        <jdkTarget>8</jdkTarget>
+        <javadocSource>9</javadocSource>
+        <jdkTarget>9</jdkTarget>
+        <maven.compiler.release>9</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <slf4j-version>1.6.1</slf4j-version>
         <project.build.outputTimestamp>2025-04-29T06:22:19Z</project.build.outputTimestamp>

--- a/src/main/java/org/fusesource/jansi/internal/JansiLoader.java
+++ b/src/main/java/org/fusesource/jansi/internal/JansiLoader.java
@@ -158,7 +158,7 @@ public class JansiLoader {
                     return "Read size different (" + numRead1 + " vs " + numRead2 + ")";
                 }
                 // Otherwise same number of bytes read
-                if (!Arrays.equals(buffer1, buffer2)) {
+                if (!Arrays.equals(buffer1, 0, numRead1, buffer2, 0, numRead2)) {
                     return "Content differs";
                 }
                 // Otherwise same bytes read, so continue ...


### PR DESCRIPTION
Color output in maven stopped working some time ago in Fedora. I don't remember if the issue started happening in Fedora 41 or Fedora 43, though.

Debugging the issue, it seems that (at least with JDK 21), reading n bytes from an input stream, where n is lower than the buffer length, doesn't clear the remaining buffer with zeroes, leaving those bytes as were retrieved from a previous read. This causes the comparison in `JansiLoader.contentsEquals` to fail, as it's comparing the full buffer length, instead of taking into account the number of bytes read in each iteration.

I'm seing the JDK target in the pom as 8, but in the github actions, I see the JDK is 9 and 11. May I update the target in the pom to JDK 9 as well? That allows me to use the `equals` method that supports comparing ranges. Otherwise, I'll have to manually clear the buffer with zeroes before reading, so that the comparison works.
