### PR TITLE
Fix native library loading failure due to buffer comparison bug

### DIFF
--- a/src/main/java/org/fusesource/jansi/internal/JansiLoader.java
+++ b/src/main/java/org/fusesource/jansi/internal/JansiLoader.java
@@ -40,7 +40,6 @@ import java.io.InputStream;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
-import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Properties;
@@ -158,8 +157,10 @@ public class JansiLoader {
                     return "Read size different (" + numRead1 + " vs " + numRead2 + ")";
                 }
                 // Otherwise same number of bytes read
-                if (!Arrays.equals(buffer1, buffer2)) {
-                    return "Content differs";
+                for (int i = 0; i < numRead1; i++) {
+                    if (buffer1[i] != buffer2[i]) {
+                        return "Content differs";
+                    }
                 }
                 // Otherwise same bytes read, so continue ...
             } else {


### PR DESCRIPTION
## Summary
- Fix `contentsEquals()` in `JansiLoader` to compare only the bytes actually read from each stream, instead of comparing the entire 8192-byte buffer via `Arrays.equals()`
- On the final chunk of a stream, bytes beyond the read count contain stale data from the previous iteration, causing a false "Content differs" mismatch that prevents the native library from loading
- Uses a JDK 8-compatible byte-by-byte loop instead of the JDK 9+ `Arrays.equals(byte[], int, int, byte[], int, int)` overload

Fixes #317

## Test plan
- [x] Verified the project compiles successfully
- [ ] Test on JDK 21 + Fedora/Linux to confirm native library loads and ANSI color output works
- [ ] Test on JDK 8 to confirm backwards compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_Claude Code on behalf of Guillaume Nodet_